### PR TITLE
[Feature] #3 - Create Modal, Bottomsheet Component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "linenow-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "jotai": "^2.9.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.26.2",
@@ -1327,14 +1328,14 @@
       "version": "15.7.12",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
       "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.5",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.5.tgz",
       "integrity": "sha512-WeqMfGJLGuLCqHGYRGHxnKrXcTitc6L/nBUWfWPcTarG3t9PsquqUMuVeXZeca+mglY4Vo5GZjCi0A3Or2lnxA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -2636,6 +2637,27 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/jotai": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.9.3.tgz",
+      "integrity": "sha512-IqMWKoXuEzWSShjd9UhalNsRGbdju5G2FrqNLQJT+Ih6p41VNYe2sav5hnwQx4HJr25jq9wRqvGSWGviGG6Gjw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=17.0.0",
+        "react": ">=17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "jotai": "^2.9.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.26.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,12 +7,14 @@ import GlobalStyle from "@styles/global";
 import { RouterProvider } from "react-router-dom";
 import router from "@routes/router";
 import Modal from "@components/modal/Modal";
+import Bottomsheet from "@components/bottomsheet/Bottomsheet";
 
 function App() {
   return (
     <ThemeProvider theme={theme}>
       <GlobalStyle />
       <Modal />
+      <Bottomsheet />
       <RouterProvider router={router} />
     </ThemeProvider>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,11 +6,13 @@ import GlobalStyle from "@styles/global";
 // router
 import { RouterProvider } from "react-router-dom";
 import router from "@routes/router";
+import Modal from "@components/modal/Modal";
 
 function App() {
   return (
     <ThemeProvider theme={theme}>
       <GlobalStyle />
+      <Modal />
       <RouterProvider router={router} />
     </ThemeProvider>
   );

--- a/src/atoms/bottomsheet.ts
+++ b/src/atoms/bottomsheet.ts
@@ -1,0 +1,8 @@
+import { atom } from "jotai";
+
+// props
+import { BottomsheetProps } from "@components/bottomsheet/Bottomsheet";
+
+export const bottomsheetAtom = atom<BottomsheetProps>({
+  isOpen: false,
+});

--- a/src/atoms/modal.ts
+++ b/src/atoms/modal.ts
@@ -1,0 +1,11 @@
+import { atom } from "jotai";
+
+// props
+import { ModalProps } from "@components/modal/Modal";
+
+export const modalAtom = atom<ModalProps>({
+  isOpen: false,
+  title: "",
+  secondButton: {},
+  primaryButton: {},
+});

--- a/src/atoms/modal.ts
+++ b/src/atoms/modal.ts
@@ -5,7 +5,4 @@ import { ModalProps } from "@components/modal/Modal";
 
 export const modalAtom = atom<ModalProps>({
   isOpen: false,
-  title: "",
-  secondButton: {},
-  primaryButton: {},
 });

--- a/src/components/bottomsheet/Bottomsheet.styled.ts
+++ b/src/components/bottomsheet/Bottomsheet.styled.ts
@@ -1,0 +1,25 @@
+import styled from "styled-components";
+
+export const BottomsheetBackground = styled.div`
+  position: fixed;
+  transform: translate(-50%, -50%);
+  top: 50%;
+  left: 50%;
+  z-index: 20;
+  width: 100%;
+  max-width: 540px;
+  height: 100%;
+  background-color: rgb(15 15 15 / 70%);
+
+  display: flex;
+  align-items: end;
+  justify-content: center;
+`;
+
+export const BottomsheetContainer = styled.section`
+  background-color: ${({ theme }) => theme.colors.background.white};
+  padding: 2rem 1rem 0.5rem 1rem;
+  border-radius: 0.75rem 0.75rem 0rem 0rem;
+
+  width: 100%;
+`;

--- a/src/components/bottomsheet/Bottomsheet.tsx
+++ b/src/components/bottomsheet/Bottomsheet.tsx
@@ -1,0 +1,28 @@
+import { ReactNode } from "react";
+
+// component
+import {
+  BottomsheetBackground,
+  BottomsheetContainer,
+} from "./Bottomsheet.styled";
+
+// atom
+import { useAtomValue } from "jotai";
+import { bottomsheetAtom } from "@atoms/bottomsheet";
+
+export interface BottomsheetProps {
+  isOpen: boolean;
+  children?: ReactNode;
+}
+
+const Bottomsheet = () => {
+  const bottomsheet = useAtomValue(bottomsheetAtom);
+
+  return bottomsheet.isOpen ? (
+    <BottomsheetBackground>
+      <BottomsheetContainer>{bottomsheet.children}</BottomsheetContainer>
+    </BottomsheetBackground>
+  ) : null;
+};
+
+export default Bottomsheet;

--- a/src/components/bottomsheet/Bottomsheet.tsx
+++ b/src/components/bottomsheet/Bottomsheet.tsx
@@ -6,9 +6,8 @@ import {
   BottomsheetContainer,
 } from "./Bottomsheet.styled";
 
-// atom
-import { useAtomValue } from "jotai";
-import { bottomsheetAtom } from "@atoms/bottomsheet";
+// hook
+import useBottomsheet from "@hooks/useBottomsheet";
 
 export interface BottomsheetProps {
   isOpen: boolean;
@@ -16,7 +15,7 @@ export interface BottomsheetProps {
 }
 
 const Bottomsheet = () => {
-  const bottomsheet = useAtomValue(bottomsheetAtom);
+  const { bottomsheet } = useBottomsheet();
 
   return bottomsheet.isOpen ? (
     <BottomsheetBackground>

--- a/src/components/button/Button.styled.ts
+++ b/src/components/button/Button.styled.ts
@@ -84,8 +84,8 @@ export const DefaultButton = styled.button<DefaultButtonProps>`
   ${({ $shape }) => {
     if ($shape == "outline") {
       return css`
-        border: 1px;
-        background-color: clear;
+        border: 1px solid;
+        background-color: transparent;
       `;
     }
   }}

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -21,7 +21,7 @@ export interface ButtonProps
   size?: ButtonSizeType;
   scheme?: ButtonSchemeType;
   shape?: ButtonShapeType;
-  children: ReactNode;
+  children?: ReactNode;
 }
 
 const Button = ({

--- a/src/components/button/ButtonLayout.tsx
+++ b/src/components/button/ButtonLayout.tsx
@@ -1,0 +1,30 @@
+import styled, { css } from "styled-components";
+
+interface ButtonLayoutProps {
+  $col: number;
+  $rowGap?: string;
+  $colGap?: string;
+}
+
+const ButtonLayout = styled.section<ButtonLayoutProps>`
+  display: grid;
+  ${({ $col }) => {
+    return css`
+      grid-template-columns: repeat(${$col}, 1fr);
+    `;
+  }}
+
+  ${({ $rowGap }) => {
+    return css`
+      row-gap: ${$rowGap !== undefined ? $rowGap : "0.5rem"};
+    `;
+  }}
+
+  ${({ $colGap }) => {
+    return css`
+      column-gap: ${$colGap !== undefined ? $colGap : "0.5rem"};
+    `;
+  }}
+`;
+
+export default ButtonLayout;

--- a/src/components/layout/PageLayout.tsx
+++ b/src/components/layout/PageLayout.tsx
@@ -1,6 +1,6 @@
 import { Outlet } from "react-router-dom";
 
-const Layout = () => {
+const PageLayout = () => {
   return (
     <section>
       <header>네비게이션</header>
@@ -12,4 +12,4 @@ const Layout = () => {
   );
 };
 
-export default Layout;
+export default PageLayout;

--- a/src/components/modal/Modal.styled.ts
+++ b/src/components/modal/Modal.styled.ts
@@ -2,11 +2,13 @@ import styled from "styled-components";
 
 export const ModalBackground = styled.div`
   position: fixed;
-  top: 0;
-  left: 0;
+  transform: translate(-50%, -50%);
+  top: 50%;
+  left: 50%;
 
   z-index: 30;
   width: 100%;
+  max-width: 540px;
   height: 100%;
   background-color: rgb(15 15 15 / 70%);
 

--- a/src/components/modal/Modal.styled.ts
+++ b/src/components/modal/Modal.styled.ts
@@ -1,0 +1,45 @@
+import styled from "styled-components";
+
+export const ModalBackground = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+
+  z-index: 30;
+  width: 100%;
+  height: 100%;
+  background-color: rgb(15 15 15 / 70%);
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const ModalContainer = styled.div`
+  background-color: ${({ theme }) => theme.colors.background.white};
+  padding: 1.25rem;
+  border-radius: 0.75rem;
+
+  min-width: 21rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+`;
+
+export const ModalTextWrapper = styled.div`
+  padding: 0 0.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+`;
+
+export const ModalTextTitle = styled.h1`
+  ${({ theme }) => theme.fonts.h1}
+  color: ${({ theme }) => theme.colors.font.black};
+`;
+
+export const ModalTextSub = styled.span`
+  ${({ theme }) => theme.fonts.b1}
+  color: ${({ theme }) => theme.colors.font.blackLight};
+  white-space: pre-line;
+`;

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -1,0 +1,66 @@
+// component
+import {
+  ModalBackground,
+  ModalContainer,
+  ModalTextSub,
+  ModalTextTitle,
+  ModalTextWrapper,
+} from "./Modal.styled";
+
+import Button, { ButtonProps } from "@components/button/Button";
+import ButtonLayout from "@components/button/ButtonLayout";
+
+// atom
+import { useAtom } from "jotai";
+import { modalAtom } from "@atoms/modal";
+
+export interface ModalProps {
+  isOpen: boolean;
+  title?: string;
+  sub?: string;
+  secondButton?: ButtonProps;
+  primaryButton?: ButtonProps;
+}
+
+const Modal = () => {
+  const [modal, setModal] = useAtom(modalAtom);
+  const colseModal = () => {
+    setModal({ isOpen: false });
+  };
+  return modal.isOpen ? (
+    <ModalBackground>
+      <ModalContainer>
+        {/* 텍스트 부분 */}
+        <ModalTextWrapper>
+          <ModalTextTitle>{modal.title}</ModalTextTitle>
+          <ModalTextSub>{modal.sub}</ModalTextSub>
+        </ModalTextWrapper>
+
+        {/* 버튼 부분 */}
+        <ButtonLayout $col={2}>
+          <Button
+            onClick={colseModal}
+            size="large"
+            scheme="grayLight"
+            shape="outline"
+            {...modal.secondButton}
+          >
+            {modal.secondButton?.children}
+          </Button>
+
+          <Button
+            onClick={colseModal}
+            size="large"
+            scheme="blue"
+            shape="fill"
+            {...modal.primaryButton}
+          >
+            {modal.primaryButton?.children}
+          </Button>
+        </ButtonLayout>
+      </ModalContainer>
+    </ModalBackground>
+  ) : null;
+};
+
+export default Modal;

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -10,23 +10,19 @@ import {
 import Button, { ButtonProps } from "@components/button/Button";
 import ButtonLayout from "@components/button/ButtonLayout";
 
-// atom
-import { useAtom } from "jotai";
-import { modalAtom } from "@atoms/modal";
+// hook
+import useModal from "@hooks/useModal";
 
 export interface ModalProps {
   isOpen: boolean;
   title?: string;
   sub?: string;
-  secondButton?: ButtonProps;
-  primaryButton?: ButtonProps;
+  secondButton?: Omit<ButtonProps, "size" | "scheme" | "shape">;
+  primaryButton?: Omit<ButtonProps, "size" | "scheme" | "shape">;
 }
 
 const Modal = () => {
-  const [modal, setModal] = useAtom(modalAtom);
-  const colseModal = () => {
-    setModal({ isOpen: false });
-  };
+  const { closeModal, modal } = useModal();
 
   return modal.isOpen ? (
     <ModalBackground>
@@ -40,23 +36,23 @@ const Modal = () => {
         {/* 버튼 부분 */}
         <ButtonLayout $col={2}>
           <Button
-            onClick={colseModal}
+            onClick={closeModal}
             size="large"
             scheme="grayLight"
             shape="outline"
             {...modal.secondButton}
           >
-            {modal.secondButton?.children}
+            {modal.secondButton?.children || "이전으로"}
           </Button>
 
           <Button
-            onClick={colseModal}
+            onClick={closeModal}
             size="large"
             scheme="blue"
             shape="fill"
             {...modal.primaryButton}
           >
-            {modal.primaryButton?.children}
+            {modal.primaryButton?.children || "확인"}
           </Button>
         </ButtonLayout>
       </ModalContainer>

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -27,6 +27,7 @@ const Modal = () => {
   const colseModal = () => {
     setModal({ isOpen: false });
   };
+
   return modal.isOpen ? (
     <ModalBackground>
       <ModalContainer>

--- a/src/hooks/useBottomsheet.ts
+++ b/src/hooks/useBottomsheet.ts
@@ -1,0 +1,21 @@
+import { useAtom } from "jotai";
+import { bottomsheetAtom } from "@atoms/bottomsheet";
+import { BottomsheetProps } from "@components/bottomsheet/Bottomsheet";
+
+const useBottomsheet = () => {
+  const [bottomsheet, setBottomseheet] = useAtom(bottomsheetAtom);
+
+  const openBottomsheet = (
+    bottomsheetProps: Omit<BottomsheetProps, "isOpen">
+  ) => {
+    setBottomseheet({ isOpen: true, ...bottomsheetProps });
+  };
+
+  const closeBottomsheet = () => {
+    setBottomseheet({ isOpen: false });
+  };
+
+  return { openBottomsheet, closeBottomsheet, bottomsheet };
+};
+
+export default useBottomsheet;

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -1,0 +1,21 @@
+import { useAtom } from "jotai";
+import { modalAtom } from "@atoms/modal";
+import { ModalProps } from "@components/modal/Modal";
+
+const useModal = () => {
+  const [modal, setModal] = useAtom(modalAtom);
+
+  const openModal = (modalProps: Omit<ModalProps, "isOpen">) => {
+    setModal({ isOpen: true, ...modalProps });
+  };
+
+  const closeModal = () => {
+    setModal({
+      isOpen: false,
+    });
+  };
+
+  return { openModal, closeModal, modal };
+};
+
+export default useModal;

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -1,9 +1,22 @@
+import { modalAtom } from "@atoms/modal";
 import Button from "@components/button/Button";
+import { useSetAtom } from "jotai";
 
 const MainPage = () => {
+  const setModal = useSetAtom(modalAtom);
+  const openModal = () => {
+    setModal({
+      isOpen: true,
+      title: "예시 모달입니다",
+      sub: "예시 모달에 대한 내용입니다.\n예시...",
+      secondButton: { children: "이전으로" },
+      primaryButton: { children: "안녕", disabled: true },
+    });
+  };
   return (
     <div>
-      <Button>버튼</Button>
+      <Button onClick={openModal}>모달 오픈 버튼</Button>
+      <Button scheme="lime">바텀시트 오픈 버튼</Button>
     </div>
   );
 };

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -1,44 +1,49 @@
 // component
 import ButtonLayout from "@components/button/ButtonLayout";
 import Button from "@components/button/Button";
+import useBottomsheet from "@hooks/useBottomsheet";
+import useModal from "@hooks/useModal";
 
-// atom
-import { useSetAtom } from "jotai";
-import { modalAtom } from "@atoms/modal";
-import { bottomsheetAtom } from "@atoms/bottomsheet";
+// hook
 
 const MainPage = () => {
-  const setModal = useSetAtom(modalAtom);
-  const openModal = () => {
-    setModal({
-      isOpen: true,
-      title: "예시 모달입니다",
-      sub: "예시 모달에 대한 내용입니다.\n예시...",
-      secondButton: { children: "이전으로" },
-      primaryButton: { children: "안녕", disabled: true },
-    });
-  };
+  const { openBottomsheet } = useBottomsheet();
+  const { openModal } = useModal();
 
-  const setBottomsheet = useSetAtom(bottomsheetAtom);
-  const openBottomsheet = () => {
-    setBottomsheet({
-      isOpen: true,
-      children: <Content />,
-    });
-  };
-
-  const Content = () => {
+  // 바텀시트를 여는 버튼
+  const OpenBottomsheetButton = () => {
     return (
-      <ButtonLayout $col={1}>
-        <Button onClick={openModal}>모달 오픈 버튼</Button>
-      </ButtonLayout>
+      <Button
+        onClick={() =>
+          openBottomsheet({ children: <ModalBottomsheetContent /> })
+        }
+      >
+        바텀시트 열기 버튼
+      </Button>
+    );
+  };
+
+  // 바텀시트 내부 요소
+  const ModalBottomsheetContent = () => {
+    return (
+      <>
+        <h1>클릭해서 모달을 열어보세요!</h1>
+        <Button
+          onClick={() =>
+            openModal({
+              title: "잘하셨습니다.",
+              sub: "바텀시트와, 모달을 hook으로 \n손쉽게 관리해봐요.",
+            })
+          }
+        >
+          모달 열기 버튼
+        </Button>
+      </>
     );
   };
   return (
     <div>
-      <Button onClick={openBottomsheet} scheme="lime">
-        바텀시트 오픈 버튼
-      </Button>
+      <OpenBottomsheetButton />
     </div>
   );
 };

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -1,6 +1,11 @@
-import { modalAtom } from "@atoms/modal";
+// component
+import ButtonLayout from "@components/button/ButtonLayout";
 import Button from "@components/button/Button";
+
+// atom
 import { useSetAtom } from "jotai";
+import { modalAtom } from "@atoms/modal";
+import { bottomsheetAtom } from "@atoms/bottomsheet";
 
 const MainPage = () => {
   const setModal = useSetAtom(modalAtom);
@@ -13,10 +18,27 @@ const MainPage = () => {
       primaryButton: { children: "안녕", disabled: true },
     });
   };
+
+  const setBottomsheet = useSetAtom(bottomsheetAtom);
+  const openBottomsheet = () => {
+    setBottomsheet({
+      isOpen: true,
+      children: <Content />,
+    });
+  };
+
+  const Content = () => {
+    return (
+      <ButtonLayout $col={1}>
+        <Button onClick={openModal}>모달 오픈 버튼</Button>
+      </ButtonLayout>
+    );
+  };
   return (
     <div>
-      <Button onClick={openModal}>모달 오픈 버튼</Button>
-      <Button scheme="lime">바텀시트 오픈 버튼</Button>
+      <Button onClick={openBottomsheet} scheme="lime">
+        바텀시트 오픈 버튼
+      </Button>
     </div>
   );
 };

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -1,7 +1,7 @@
 import { createBrowserRouter } from "react-router-dom";
 
 // components
-import Layout from "@components/layout/Layout";
+import PageLayout from "@components/layout/PageLayout";
 
 // pages
 import MainPage from "@pages/main/MainPage";
@@ -15,7 +15,7 @@ const router = createBrowserRouter([
   { path: "/", children: [{ path: "", element: <MainPage /> }] },
   {
     path: "/",
-    element: <Layout />,
+    element: <PageLayout />,
     children: [
       { path: "", element: <MainPage /> },
       { path: "booth/:boothID", element: <BoothDetailPage /> },

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -4,7 +4,7 @@ const GlobalStyle = createGlobalStyle`
 // 폰트설정
 @font-face {
     font-family:"Pretendard";
-    src: url("../assets/fonts/PretendardVariable.woff2");
+    src: url("src/assets/fonts/PretendardVariable.woff2");
 }
 
 // 초기 html 설정

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,5 +1,3 @@
-import { DISABLE_SPEEDY } from "styled-components/dist/constants";
-
 const fontGenerator = (
   fontFamily = "Pretendard",
   fontSize = "1.6rem",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "paths": {
       "@atoms/*": ["src/atoms/*"],
       "@components/*": ["src/components/*"],
+      "@hooks/*": ["src/hooks/*"],
       "@pages/*": ["src/pages/*"],
       "@routes/*": ["src/routes/*"],
       "@styles/*": ["src/styles/*"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
+      "@atoms/*": ["src/atoms/*"],
       "@components/*": ["src/components/*"],
       "@pages/*": ["src/pages/*"],
       "@routes/*": ["src/routes/*"],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     alias: {
       "@atoms": path.resolve(__dirname, "src/atoms"),
       "@components": path.resolve(__dirname, "src/components"),
+      "@hooks": path.resolve(__dirname, "src/hooks"),
       "@pages": path.resolve(__dirname, "src/pages"),
       "@routes": path.resolve(__dirname, "src/routes"),
       "@styles": path.resolve(__dirname, "src/styles"),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
+      "@atoms": path.resolve(__dirname, "src/atoms"),
       "@components": path.resolve(__dirname, "src/components"),
       "@pages": path.resolve(__dirname, "src/pages"),
       "@routes": path.resolve(__dirname, "src/routes"),


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
- 모달 컴포넌트를 생성했습니다.
- 바텀시트 컴포넌트를 생성했습니다.

## 🚨 참고 사항
### 모달 사용 방법
```typescript
const { modal, openModal , closeModal} = useModal();

  const handleOpenModalButton = () => {
    openModal({
      title: "모달 테스트",
      sub: "훅을 통해 모달을 \n편리하게 관리해봐요",
    });
  };

<Button onClick={handleOpenModalButton}>모달 열기 버튼</Button>
```
`useModal` 훅을 통해, openModal, colseModal 함수를 사용할 수 있습니다. **버튼을 다루는 함수를 명명 한 뒤** 버튼의 `onClick 속성`에 **모달 열기와 관련된 함수**를 할당해주면 됩니다.

모달의 interface는 다음과 같습니다.
- interface ModalProps

|변수명|타입|설명|
|------|---|---|
|isOpen|boolean|모달의 열림 상태를 관리합니다. 보통 useModal을 사용하면 open, close 이 자동으로 isOpen 값을 결정해주기 때문에 설정할 일이 없습니다.|
|title|string|모달의 상단 H1 텍스트의 제목입니다.|
|sub|string|모달의 n1 서브 제목입니다. \n을 통해 개행을 할 수 있습니다.|
|secondButton|ButtonProps|모달의 왼쪽(선 타입) 버튼 입니다. 지정하지 않을 시 '이전으로'라는이름으로 모달이 닫히는 함수가 내장되어있습니다.<br/>shpae, scheme, size 지정불가|
|primaryButton|ButtonProps|모달의 오른쪽(채움 타입) 버튼 입니다. 지정하지 않을 시 '확인'라는이름으로 모달이 닫히는 함수가 내장되어있습니다. <br/>shpae, scheme, size 지정불가|


### 바텀시트 사용 방법
```typescript
const { bottomsheet, openBottomsheet, closeBottomsheet } = useBottomsheet();

  const handleOpenBottomSheetButton = () => {
    openBottomsheet({ children: <ModalBottomsheetContent /> });
  };

      <Button onClick={() => handleOpenBottomSheetButton}>
        바텀시트 열기 버튼
      </Button>
```

`useBottomsheet`역시 useModal 과 동일한 방식으로 사용해주시면 됩니다.

바텀시트의 interface는 다음과 같습니다.
|변수명|타입|설명|
|------|---|---|
|isOpen|boolean|바텀시트의 열림 상태를 관리합니다. 보통 useBottomsheet을 사용하면 open, close 이 자동으로 isOpen 값을 결정해주기 때문에 설정할 일이 없습니다.|
|children|ReactNode|바텀시트 내부 구성 요소입니다. 컴포넌트를 생성해 할당해주시면 됩니다.|



## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?


## 📟 관련 이슈
- Resolved: #3
