### PR TITLE
[Feature] #7 - Creating Depth Default Layout

### DIFF
--- a/src/components/boothCard/BoothCard.styled.ts
+++ b/src/components/boothCard/BoothCard.styled.ts
@@ -46,6 +46,7 @@ export const BoothCardInformationNameLabel = styled.div`
   white-space: nowrap;
   text-overflow: ellipsis;
 
+  padding-bottom: 0.125rem;
   ${({ theme }) => theme.fonts.h3}
   color:${({ theme }) => theme.colors.font.black};
 `;

--- a/src/components/bottomButton/BottomButton.styled.ts
+++ b/src/components/bottomButton/BottomButton.styled.ts
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+
+export const BottomButtonWrapper = styled.section`
+  position: fixed;
+  transform: translate(-50%, 0%);
+  bottom: 0;
+  left: 50%;
+  width: 200px;
+  height: 200px;
+`;

--- a/src/components/bottomButton/BottomButton.styled.ts
+++ b/src/components/bottomButton/BottomButton.styled.ts
@@ -1,10 +1,40 @@
 import styled from "styled-components";
 
 export const BottomButtonWrapper = styled.section`
+  display: flex;
+  gap: 0.75rem;
+
   position: fixed;
   transform: translate(-50%, 0%);
   bottom: 0;
   left: 50%;
-  width: 200px;
-  height: 200px;
+
+  width: 100%;
+  max-width: 540px;
+
+  padding: 1rem;
+  padding-bottom: 0.5rem;
+  border-radius: 12px 12px 0px 0px;
+
+  background-color: ${({ theme }) => theme.colors.background.white};
+  box-shadow: 0px 0px 4px 4px rgba(26, 30, 39, 0.1);
+
+  flex-direction: column;
+`;
+
+export const BottomButtonInformationWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: end;
+  gap: 0.5rem;
+
+  height: 1.25rem;
+  padding: 0 0.25rem;
+  ${({ theme }) => theme.fonts.chip}
+  color: ${({ theme }) => theme.colors.font.black};
+
+  .blue {
+    ${({ theme }) => theme.fonts.b2_b}
+    color: ${({ theme }) => theme.colors.font.blue};
+  }
 `;

--- a/src/components/bottomButton/BottomButton.tsx
+++ b/src/components/bottomButton/BottomButton.tsx
@@ -1,0 +1,7 @@
+import * as S from "./BottomButton.styled";
+
+const BottomButton = () => {
+  return <S.BottomButtonWrapper>바텀버튼</S.BottomButtonWrapper>;
+};
+
+export default BottomButton;

--- a/src/components/bottomButton/BottomButton.tsx
+++ b/src/components/bottomButton/BottomButton.tsx
@@ -1,7 +1,28 @@
-import * as S from "./BottomButton.styled";
+import { ReactNode } from "react";
 
-const BottomButton = () => {
-  return <S.BottomButtonWrapper>바텀버튼</S.BottomButtonWrapper>;
+import * as S from "./BottomButton.styled";
+import ButtonLayout from "@components/button/ButtonLayout";
+
+interface BottomButtonProps {
+  children?: ReactNode;
+  informationTitle?: string;
+  informationSub?: string;
+}
+const BottomButton = ({
+  children,
+  informationTitle,
+  informationSub,
+}: BottomButtonProps) => {
+  return (
+    <S.BottomButtonWrapper>
+      <S.BottomButtonInformationWrapper>
+        <span>{informationTitle}</span>
+        <span className="blue">{informationSub}</span>
+      </S.BottomButtonInformationWrapper>
+
+      <ButtonLayout $col={1}>{children}</ButtonLayout>
+    </S.BottomButtonWrapper>
+  );
 };
 
 export default BottomButton;

--- a/src/components/button/CustomButton.tsx
+++ b/src/components/button/CustomButton.tsx
@@ -12,14 +12,14 @@ interface LinkButtonProps {
   to: string;
 }
 
-interface IconButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+// IconButton
+interface IconProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   icon: string;
   iconSize: string;
   touchSize?: string;
 }
 
-type IconLinkButtonProps = IconButtonProps & LinkButtonProps;
+type IconLinkButtonProps = IconProps & LinkButtonProps;
 export const IconLinkButton = ({
   to,
   icon,
@@ -35,6 +35,23 @@ export const IconLinkButton = ({
   );
 };
 
+type IconButtonProps = IconProps & CommonButtonProps;
+export const IconButton = ({
+  onClick,
+  icon,
+  iconSize,
+  touchSize = iconSize,
+  ...props
+}: IconButtonProps) => {
+  return (
+    <button onClick={onClick} {...props}>
+      <S.IconButtonWrapper $iconSize={iconSize}>
+        <img src={`/icons/icon_${icon}.svg`} />
+      </S.IconButtonWrapper>
+    </button>
+  );
+};
+
 type IconLableLinkButtonProps = IconLabelProps & LinkButtonProps;
 export const IconLabelLinkButton = ({
   to,
@@ -47,6 +64,7 @@ export const IconLabelLinkButton = ({
   );
 };
 
+// ChipButton
 type ChipButtonProps = ChipProps & CommonButtonProps;
 export const ChipButton = ({
   disabled,

--- a/src/components/navigation/Navigation.styled.ts
+++ b/src/components/navigation/Navigation.styled.ts
@@ -1,0 +1,14 @@
+import styled from "styled-components";
+
+export const NavigationWrapper = styled.header`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+
+  padding: 1rem 1.5rem;
+`;
+
+export const NavigationLabel = styled.h2`
+  ${({ theme }) => theme.fonts.h2};
+  color: ${({ theme }) => theme.colors.font.black};
+`;

--- a/src/components/navigation/Navigation.tsx
+++ b/src/components/navigation/Navigation.tsx
@@ -1,0 +1,5 @@
+const Navigation = () => {
+  return <header>네비게이션</header>;
+};
+
+export default Navigation;

--- a/src/components/navigation/Navigation.tsx
+++ b/src/components/navigation/Navigation.tsx
@@ -1,5 +1,36 @@
+import { useLocation } from "react-router-dom";
+
+import * as S from "./Navigation.styled";
+import { IconButton } from "@components/button/CustomButton";
+
 const Navigation = () => {
-  return <header>네비게이션</header>;
+  const location = useLocation();
+
+  const getNavigationTitle = () => {
+    switch (location.pathname) {
+      case "/my-waiting":
+        return <S.NavigationLabel>나의 줄서기</S.NavigationLabel>;
+      case "/setting":
+        return <S.NavigationLabel>설정</S.NavigationLabel>;
+      default:
+        return null;
+    }
+  };
+
+  const handleBackButton = () => {
+    window.history.back();
+  };
+
+  return (
+    <S.NavigationWrapper>
+      <IconButton
+        onClick={handleBackButton}
+        icon="left_gray"
+        iconSize="1.5rem"
+      />
+      {getNavigationTitle()}
+    </S.NavigationWrapper>
+  );
 };
 
 export default Navigation;

--- a/src/components/waitingCard/WaitingCard.styled.ts
+++ b/src/components/waitingCard/WaitingCard.styled.ts
@@ -3,6 +3,8 @@ import * as A from "@styles/animation";
 import { Link } from "react-router-dom";
 
 export const WaitingCardWrapper = styled(Link)`
+  flex-direction: column;
+
   padding: 1.25rem 1rem;
   border: 1px solid;
   border-color: ${({ theme }) => theme.colors.border.gray100};

--- a/src/layouts/DefaultPageLayout.tsx
+++ b/src/layouts/DefaultPageLayout.tsx
@@ -1,13 +1,14 @@
-import { Outlet } from "react-router-dom";
+import { Outlet, useLocation } from "react-router-dom";
+
+import Navigation from "@components/navigation/Navigation";
 
 const DefaultPageLayout = () => {
   return (
     <section>
-      <header>네비게이션</header>
+      <Navigation />
       <section>
         <Outlet />
       </section>
-      <footer>바텀 버튼</footer>
     </section>
   );
 };

--- a/src/layouts/DefaultPageLayout.tsx
+++ b/src/layouts/DefaultPageLayout.tsx
@@ -1,16 +1,22 @@
 import { Outlet } from "react-router-dom";
 
 import Navigation from "@components/navigation/Navigation";
+import styled from "styled-components";
 
 const DefaultPageLayout = () => {
   return (
-    <section>
+    <>
       <Navigation />
-      <section>
+      <OutletWrapper>
         <Outlet />
-      </section>
-    </section>
+      </OutletWrapper>
+    </>
   );
 };
 
 export default DefaultPageLayout;
+
+const OutletWrapper = styled.section`
+  flex-grow: 1;
+  background-color: ${({ theme }) => theme.colors.background.white};
+`;

--- a/src/layouts/DefaultPageLayout.tsx
+++ b/src/layouts/DefaultPageLayout.tsx
@@ -1,4 +1,4 @@
-import { Outlet, useLocation } from "react-router-dom";
+import { Outlet } from "react-router-dom";
 
 import Navigation from "@components/navigation/Navigation";
 

--- a/src/pages/boothDetail/BoothDetailPage.tsx
+++ b/src/pages/boothDetail/BoothDetailPage.tsx
@@ -1,5 +1,12 @@
+import BottomButton from "@components/bottomButton/BottomButton";
+
 const BoothDetailPage = () => {
-  return <div>부스 디테일</div>;
+  return (
+    <>
+      <BottomButton />
+      <div>부스 디테일 페이지</div>
+    </>
+  );
 };
 
 export default BoothDetailPage;

--- a/src/pages/boothDetail/BoothDetailPage.tsx
+++ b/src/pages/boothDetail/BoothDetailPage.tsx
@@ -1,9 +1,12 @@
 import BottomButton from "@components/bottomButton/BottomButton";
+import Button from "@components/button/Button";
 
 const BoothDetailPage = () => {
   return (
     <>
-      <BottomButton />
+      <BottomButton informationTitle="전체 줄" informationSub="123 팀">
+        <Button>대기걸기</Button>
+      </BottomButton>
       <div>부스 디테일 페이지</div>
     </>
   );

--- a/src/pages/main/_components/navigation/MainNavigation.tsx
+++ b/src/pages/main/_components/navigation/MainNavigation.tsx
@@ -34,8 +34,8 @@ const MainNavigation = ({ isFold }: MainNavigationProps) => {
           iconSize="1rem"
         >
           <S.MainNavigationTitleLabel className={isFold ? "fold" : "unfold"}>
-            <p>나의 대기</p>
-            <p className="lime">3개</p>
+            <span>나의 대기</span>
+            <span className="lime">3개</span>
           </S.MainNavigationTitleLabel>
         </IconLabelLinkButton>
 

--- a/src/styles/animation.ts
+++ b/src/styles/animation.ts
@@ -5,7 +5,7 @@ export const changeFoldStateAnimation = css`
 `;
 
 export const onClickButtonAnimation = css`
-  cursor: "pointer";
+  cursor: pointer;
   transition: transform 0.3s;
   &:hover {
     transform: scale(1.05);

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -1,60 +1,28 @@
 import { createGlobalStyle } from "styled-components";
 
 const GlobalStyle = createGlobalStyle`
-a {
-	text-decoration-line: none;
-}
-
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed, 
-figure, figcaption, footer, header, hgroup, 
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video, button {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font: inherit;
-	vertical-align: baseline;
-	background-color: transparent;
-	box-sizing: border-box;
-}
-/* HTML5 display-role reset for older browsers */
-article, aside, details, figcaption, figure, 
-footer, header, hgroup, menu, nav, section {
-	display: block;
-}
-body {
-	line-height: 1;
-}
-img{border:none}
-ol, ul {
-	list-style: none;
-}
-blockquote, q {
-	quotes: none;
-}
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
-}
-table {
-	border-collapse: collapse;
-	border-spacing: 0;
-}
+*{box-sizing:border-box}
+body, button, dd, dl, dt, fieldset, form, h1, h2, h3, h4, h5, h6, input, legend, li, ol, p, select, table, td, textarea, th, ul {margin:0;padding:0}
+body, button, input, select, table, textarea {font-size:12px;line-height:16px;color:#202020;font-family:-apple-system, BlinkMacSystemFont, "Malgun Gothic", "맑은 고딕", helvetica, "Apple SD Gothic Neo", sans-serif}
+h1, h2, h3, h4, h5, h6 {font-size:inherit;line-height:inherit}
+textarea {-webkit-backface-visibility:hidden;backface-visibility:hidden;background-color:transparent;border:0;word-break:keep-all;word-wrap:break-word}
+button, input {-webkit-border-radius:0;border-radius:0;border:0}
+button {background-color:transparent}
+fieldset, img {border:0}
+img {vertical-align:top}
+ol, ul {list-style:none}
+address, em {font-style:normal}
+a {display:flex;text-decoration:none;}
+iframe {overflow:hidden;margin:0;border:0;padding:0;vertical-align:top}
+mark {background-color:transparent}
+i {font-style:normal}
 
 #root {
 	display: flex;
 	flex-direction: column;
 	overflow: hidden;
+
+	min-height: 100vh;
 }
 
 // 폰트설정


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
- 뎁스의 기본 레이아웃을 작업했습니다.
- 네비게이션
- 바텀버튼


## 🚨 참고 사항
###  바텀버튼 사용 법
```ts
const BoothDetailPage = () => {
  return (
    <>
      <BottomButton informationTitle="전체 줄" informationSub="123 팀">
        <Button>대기걸기</Button>
      </BottomButton>
      <div>부스 디테일 페이지</div>
    </>
  );
};

export default BoothDetailPage;
```

바텀버튼이 사용되는 페이지 상단이나, 하단 (편한 곳)에 Bottom Button을 삽입해줍니다. 

<img width="385" alt="Screenshot 2024-09-16 at 1 48 19 PM" src="https://github.com/user-attachments/assets/b94edca8-702b-441c-b0eb-d9c55154c1cb">

informationTitle에는 우측 상단 검은 글자
informationSub에는 우측 상단 파란 글자
children props에는 사용되는 버튼들을 넣어주시면 됩니다.


## 📸 스크린샷
|    구현 내용    |   540px   |   390px   |   320px   |
| :-------------: | :----------: | :----------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/d09a451f-dc4d-4738-8364-9ad7c85199bd" width ="250"> | <img src = "https://github.com/user-attachments/assets/0e923eea-7542-4216-974b-cf1665fee3c4" width ="250"> | <img src = "https://github.com/user-attachments/assets/d9b2440f-6922-4aef-820c-05dfe03c4194" width ="250"> |

## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?


## 📟 관련 이슈
- Resolved: #7
