### PR TITLE
[Feature] #18 Create Waiting Check Page

### DIFF
--- a/public/icons/icon_checkBox_after.svg
+++ b/public/icons/icon_checkBox_after.svg
@@ -1,0 +1,17 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_783_4037)">
+<rect width="24" height="24" rx="4" fill="#1851FF"/>
+<g clip-path="url(#clip1_783_4037)">
+<path d="M9.54998 18L3.84998 12.3L5.27498 10.875L9.54998 15.15L18.725 5.97498L20.15 7.39998L9.54998 18Z" fill="#C9CDD6"/>
+</g>
+</g>
+<rect x="0.5" y="0.5" width="23" height="23" rx="3.5" stroke="#1851FF"/>
+<defs>
+<clipPath id="clip0_783_4037">
+<rect width="24" height="24" rx="4" fill="white"/>
+</clipPath>
+<clipPath id="clip1_783_4037">
+<rect width="24" height="24" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/public/icons/icon_checkBox_before.svg
+++ b/public/icons/icon_checkBox_before.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="0.5" y="0.5" width="23" height="23" rx="3.5" stroke="#1851FF"/>
+</svg>

--- a/src/components/boothCard/BoothCard.styled.ts
+++ b/src/components/boothCard/BoothCard.styled.ts
@@ -8,7 +8,6 @@ interface BoothCardWrapperProps {
   type?: BoothCardType;
   $borderBottom?: string;
   padding?: string;
-  $animation?: boolean;
 }
 
 export const BoothCardWrapper = styled(Link)<BoothCardWrapperProps>`
@@ -19,13 +18,13 @@ export const BoothCardWrapper = styled(Link)<BoothCardWrapperProps>`
   width: 100%;
   box-sizing: border-box;
 
-  ${({ type, theme, $animation }) => css`
+  ${({ type, theme }) => css`
     padding: ${type === "detail" ? `1rem` : `0.75rem 0.25rem 1rem 0.25rem`};
     border-bottom: ${type === "detail"
       ? `none`
       : `1px solid ${theme.colors.border.gray075}`};
 
-    ${type !== "detail" && $animation && A.onClickButtonAnimation};
+    ${type !== "detail" && A.onClickButtonAnimation};
   `}
 `;
 

--- a/src/components/boothCard/BoothCard.tsx
+++ b/src/components/boothCard/BoothCard.tsx
@@ -9,7 +9,6 @@ interface BoothCardProps {
   borderBottom?: string;
   padding?: string;
   to?: string;
-  animation?: boolean;
 }
 
 const BoothCard = ({
@@ -18,7 +17,6 @@ const BoothCard = ({
   borderBottom,
   padding,
   to,
-  animation = true,
 }: BoothCardProps) => {
   return (
     <S.BoothCardWrapper
@@ -26,7 +24,6 @@ const BoothCard = ({
       to={to || "#"}
       $borderBottom={borderBottom}
       padding={padding}
-      $animation={!!to && animation}
     >
       <S.BoothCardInformationWrapper>
         <S.BoothCardInformationImage />

--- a/src/components/infobottomButton/InfoBottomButton.styled.ts
+++ b/src/components/infobottomButton/InfoBottomButton.styled.ts
@@ -1,0 +1,70 @@
+import styled from "styled-components";
+
+export const InfoBottomButtonBackground = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  position: fixed;
+  transform: translate(-50%, -50%);
+  top: 50%;
+  left: 50%;
+  z-index: 30;
+
+  width: 100%;
+  max-width: 540px;
+  height: 100%;
+
+  background-color: rgb(15 15 15 / 70%);
+`;
+
+export const InfoBottomButtonWrapper = styled.section`
+  display: flex;
+  /* gap: 0.75rem; */
+
+  position: fixed;
+  transform: translate(-50%, 0%);
+  bottom: 0;
+  left: 50%;
+
+  width: 100%;
+
+  padding: 2rem 1rem 0.5rem 1rem;
+  padding-bottom: 0.5rem;
+  border-radius: 12px 12px 0px 0px;
+
+  background-color: ${({ theme }) => theme.colors.background.white};
+  box-shadow: 0px 0px 4px 4px rgba(26, 30, 39, 0.1);
+
+  flex-direction: column;
+`;
+
+export const InfoBottomButtonInformationWrapper = styled.div`
+  display: flex;
+  gap: 0.75rem;
+
+  padding: 0 0.25rem;
+
+  flex-direction: column;
+
+  .title {
+    ${({ theme }) => theme.fonts.h1}
+    color: ${({ theme }) => theme.colors.font.black};
+  }
+
+  .subtitle {
+    ${({ theme }) => theme.fonts.b1}
+    color: ${({ theme }) => theme.colors.font.blackLight};
+    white-space: pre-line;
+  }
+`;
+
+export const InfoBottomButtonCheck = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  width: 100%;
+
+  margin-top: 1.5rem;
+  /* margin-bottom: 1.75rem; */
+`;

--- a/src/components/infobottomButton/InfoBottomButton.tsx
+++ b/src/components/infobottomButton/InfoBottomButton.tsx
@@ -1,0 +1,28 @@
+import * as S from "./InfoBottomButton.styled";
+
+interface BottomButtonProps {
+  informationTitle?: string;
+  informationSub?: string;
+  children?: React.ReactNode;
+}
+
+const InfoBottomButton = ({
+  informationTitle,
+  informationSub,
+  children,
+}: BottomButtonProps) => {
+  return (
+    <S.InfoBottomButtonBackground>
+      <S.InfoBottomButtonWrapper>
+        <S.InfoBottomButtonInformationWrapper>
+          <span className="title">{informationTitle}</span>
+          <span className="subtitle">{informationSub}</span>
+        </S.InfoBottomButtonInformationWrapper>
+
+        <S.InfoBottomButtonCheck>{children}</S.InfoBottomButtonCheck>
+      </S.InfoBottomButtonWrapper>
+    </S.InfoBottomButtonBackground>
+  );
+};
+
+export default InfoBottomButton;

--- a/src/components/infobottomButton/InfoBottomButton.tsx
+++ b/src/components/infobottomButton/InfoBottomButton.tsx
@@ -9,6 +9,7 @@ interface BottomButtonProps {
 const InfoBottomButton = ({
   informationTitle,
   informationSub,
+
   children,
 }: BottomButtonProps) => {
   return (

--- a/src/components/waitingCard/WaitingCard.styled.ts
+++ b/src/components/waitingCard/WaitingCard.styled.ts
@@ -1,8 +1,14 @@
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import * as A from "@styles/animation";
 import { Link } from "react-router-dom";
+import { WaitingCardType } from "./WaitingCard";
 
-export const WaitingCardWrapper = styled(Link)`
+interface WaitingCardWrapperProps {
+  type?: WaitingCardType;
+  $animation?: boolean;
+}
+
+export const WaitingCardWrapper = styled(Link)<WaitingCardWrapperProps>`
   flex-direction: column;
 
   padding: 1.25rem 1rem;
@@ -12,7 +18,9 @@ export const WaitingCardWrapper = styled(Link)`
 
   background-color: ${({ theme }) => theme.colors.background.white};
 
-  ${A.onClickButtonAnimation}
+  ${({ type, $animation }) => css`
+    ${type !== "check" && $animation && A.onClickButtonAnimation};
+  `}
 `;
 
 // WaitingCardTitle
@@ -29,6 +37,11 @@ export const WaitingCardTitleWrapper = styled.div`
 export const WaitingCardTitleLabel = styled.h2`
   ${({ theme }) => theme.fonts.h2};
   color: ${({ theme }) => theme.colors.font.black};
+`;
+
+export const HighlightedText = styled.span<{ type: WaitingCardType }>`
+  color: ${({ theme, type }) =>
+    type === "check" ? theme.colors.font.blue : theme.colors.font.black};
 `;
 
 // BoothInformation

--- a/src/components/waitingCard/WaitingCard.styled.ts
+++ b/src/components/waitingCard/WaitingCard.styled.ts
@@ -5,7 +5,6 @@ import { WaitingCardType } from "./WaitingCard";
 
 interface WaitingCardWrapperProps {
   type?: WaitingCardType;
-  $animation?: boolean;
 }
 
 export const WaitingCardWrapper = styled(Link)<WaitingCardWrapperProps>`
@@ -18,8 +17,8 @@ export const WaitingCardWrapper = styled(Link)<WaitingCardWrapperProps>`
 
   background-color: ${({ theme }) => theme.colors.background.white};
 
-  ${({ type, $animation }) => css`
-    ${type !== "check" && $animation && A.onClickButtonAnimation};
+  ${({ type }) => css`
+    ${type !== "check" && A.onClickButtonAnimation};
   `}
 `;
 

--- a/src/components/waitingCard/WaitingCard.tsx
+++ b/src/components/waitingCard/WaitingCard.tsx
@@ -5,51 +5,51 @@ import { ChipButton } from "@components/button/CustomButton";
 
 export type WaitingCardType = "main" | "check";
 
+interface BoothInfo {
+  peopleCount: number;
+  boothName: string;
+  location: string;
+}
+
 interface WaitingCardProps {
   type: WaitingCardType;
   remainingTeams?: number;
-  cancelButtonLabel?: string;
-  onCancelClick?: () => void;
   waitingMessage?: string;
   disabled?: boolean;
-  boothInfo: {
-    peopleCount: number;
-    boothName: string;
-    location: string;
-  };
   to?: string;
   animation?: boolean;
+  boothInfo: BoothInfo;
 }
 
 const WaitingCard = ({
   type,
   remainingTeams = 0,
-  cancelButtonLabel,
-  onCancelClick,
   waitingMessage,
   disabled = true,
-  boothInfo,
   to,
-  animation = true,
+  boothInfo,
 }: WaitingCardProps) => {
+  const onCancelClick = () => {
+    alert("대기 취소 요청이 완료되었습니다.");
+  };
+
   return (
-    <S.WaitingCardWrapper
-      to={to || "#"}
-      $animation={type !== "check" && animation}
-    >
+    <S.WaitingCardWrapper to={to || "#"}>
       <S.WaitingCardTitleWrapper>
         <S.WaitingCardTitleLabel>
-          내 앞으로{" "}
-          <S.HighlightedText type={type}>{remainingTeams}팀</S.HighlightedText>{" "}
+          내 앞으로
+          <S.HighlightedText type={type}>
+            {remainingTeams}팀
+          </S.HighlightedText>{" "}
           남았어요
         </S.WaitingCardTitleLabel>
-        {type === "main" && cancelButtonLabel && (
+        {type === "main" && (
           <ChipButton
             onClick={onCancelClick}
             scheme="grayLight"
             shape="outline"
           >
-            {cancelButtonLabel}
+            취소하기
           </ChipButton>
         )}
       </S.WaitingCardTitleWrapper>

--- a/src/components/waitingCard/WaitingCard.tsx
+++ b/src/components/waitingCard/WaitingCard.tsx
@@ -37,10 +37,8 @@ const WaitingCard = ({
     <S.WaitingCardWrapper to={to || "#"}>
       <S.WaitingCardTitleWrapper>
         <S.WaitingCardTitleLabel>
-          내 앞으로
-          <S.HighlightedText type={type}>
-            {remainingTeams}팀
-          </S.HighlightedText>{" "}
+          내 앞으로{" "}
+          <S.HighlightedText type={type}>{remainingTeams}팀</S.HighlightedText>{" "}
           남았어요
         </S.WaitingCardTitleLabel>
         {type === "main" && (

--- a/src/components/waitingCard/WaitingCard.tsx
+++ b/src/components/waitingCard/WaitingCard.tsx
@@ -1,49 +1,80 @@
-// component
 import * as S from "./WaitingCard.styled";
 import IconLabel from "@components/label/IconLabel";
 import Button from "@components/button/Button";
 import { ChipButton } from "@components/button/CustomButton";
 
-// hook
+export type WaitingCardType = "main" | "check";
 
-const WaitingCard = () => {
-  const handleOnClickCancelButton = () => {
-    alert("취소하시겠습니까?");
+interface WaitingCardProps {
+  type: WaitingCardType;
+  remainingTeams?: number;
+  cancelButtonLabel?: string;
+  onCancelClick?: () => void;
+  waitingMessage?: string;
+  disabled?: boolean;
+  boothInfo: {
+    peopleCount: number;
+    boothName: string;
+    location: string;
   };
+  to?: string;
+  animation?: boolean;
+}
+
+const WaitingCard = ({
+  type,
+  remainingTeams = 0,
+  cancelButtonLabel,
+  onCancelClick,
+  waitingMessage,
+  disabled = true,
+  boothInfo,
+  to,
+  animation = true,
+}: WaitingCardProps) => {
   return (
-    <S.WaitingCardWrapper to="/waiting/1">
+    <S.WaitingCardWrapper
+      to={to || "#"}
+      $animation={type !== "check" && animation}
+    >
       <S.WaitingCardTitleWrapper>
         <S.WaitingCardTitleLabel>
-          내 앞으로 3팀 남았어요
+          내 앞으로{" "}
+          <S.HighlightedText type={type}>{remainingTeams}팀</S.HighlightedText>{" "}
+          남았어요
         </S.WaitingCardTitleLabel>
-        <ChipButton
-          onClick={handleOnClickCancelButton}
-          scheme="grayLight"
-          shape="outline"
-        >
-          취소하기
-        </ChipButton>
+        {type === "main" && cancelButtonLabel && (
+          <ChipButton
+            onClick={onCancelClick}
+            scheme="grayLight"
+            shape="outline"
+          >
+            {cancelButtonLabel}
+          </ChipButton>
+        )}
       </S.WaitingCardTitleWrapper>
       <S.BoothInformationWrapper>
         <S.BoothInformationImage />
         <S.BoothInformaitonLabelWrapper>
           <S.BoothInformationNameLabel>
-            <span>8명</span>
+            <span>{boothInfo.peopleCount}명</span>
             <span>·</span>
-            <span>부스 -A</span>
+            <span>{boothInfo.boothName}</span>
           </S.BoothInformationNameLabel>
 
           <IconLabel icon="location_gray_light" iconSize="1rem" gap="0.12rem">
             <S.BoothInformationPositionLabel>
-              멋쟁이 사자처럼
+              {boothInfo.location}
             </S.BoothInformationPositionLabel>
           </IconLabel>
         </S.BoothInformaitonLabelWrapper>
       </S.BoothInformationWrapper>
 
-      <S.WaitingCardButtonWrapper>
-        <Button disabled>순서까지 기다려주세요</Button>
-      </S.WaitingCardButtonWrapper>
+      {type === "main" && waitingMessage && (
+        <S.WaitingCardButtonWrapper>
+          <Button disabled={disabled}>{waitingMessage}</Button>
+        </S.WaitingCardButtonWrapper>
+      )}
     </S.WaitingCardWrapper>
   );
 };

--- a/src/constants/waitingCaution.ts
+++ b/src/constants/waitingCaution.ts
@@ -1,0 +1,5 @@
+// constants.ts
+
+export const TITLE: string = "라인나우 대기 줄서기 유의사항";
+export const SUBTITLE: string =
+  "입장 미확정 또는 입장 시간을 준수하지 않으면 대기 줄서기가 자동 취소됩니다.\n아래 유의사항을 꼭 읽어주세요.";

--- a/src/pages/main/_components/navigation/MainNavigation.tsx
+++ b/src/pages/main/_components/navigation/MainNavigation.tsx
@@ -1,7 +1,6 @@
 import * as S from "./MainNavigation.styled";
 
 //component
-import IconLabel from "@components/label/IconLabel";
 import {
   IconLabelLinkButton,
   IconLinkButton,
@@ -41,7 +40,20 @@ const MainNavigation = ({ isFold }: MainNavigationProps) => {
 
         <IconLinkButton to="/setting" icon="setting_white" iconSize="1.5rem" />
       </S.MainNavigationTitleWrapper>
-      {isFold ? null : <WaitingCard />}
+      {isFold ? null : (
+        <WaitingCard
+          type="main"
+          remainingTeams={3}
+          cancelButtonLabel="취소하기"
+          onCancelClick={() => alert("취소하시겠습니까?")}
+          waitingMessage="순서까지 기다려주세요"
+          boothInfo={{
+            peopleCount: 8,
+            boothName: "부스 - A",
+            location: "멋쟁이 사자처럼",
+          }}
+        />
+      )}
     </S.MainNavigationWrapper>
   );
 };

--- a/src/pages/main/_components/navigation/MainNavigation.tsx
+++ b/src/pages/main/_components/navigation/MainNavigation.tsx
@@ -44,8 +44,6 @@ const MainNavigation = ({ isFold }: MainNavigationProps) => {
         <WaitingCard
           type="main"
           remainingTeams={3}
-          cancelButtonLabel="취소하기"
-          onCancelClick={() => alert("취소하시겠습니까?")}
           waitingMessage="순서까지 기다려주세요"
           boothInfo={{
             peopleCount: 8,

--- a/src/pages/waitingCheck/WaitingCheckPage.styled.ts
+++ b/src/pages/waitingCheck/WaitingCheckPage.styled.ts
@@ -1,0 +1,40 @@
+import styled from "styled-components";
+
+export const WaitingCheckPageTitle = styled.h1`
+  ${({ theme }) => theme.fonts.h1}
+`;
+
+export const WaitingDetailPageBoothCardWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  width: 100%;
+
+  padding: 1rem 1.25rem 1.25rem 1.25rem;
+
+  gap: 1.5rem;
+`;
+
+export const WaitingDetailPageBoothCard = styled.div`
+  border: 1px solid;
+  border-color: ${({ theme }) => theme.colors.border.gray100};
+  border-radius: 8px;
+`;
+
+export const WaitingDetailCancel = styled.div`
+  display: flex;
+  justify-content: center;
+
+  padding: 0.25rem 0px;
+
+  color: ${({ theme }) => theme.colors.font.gray};
+
+  span {
+    padding-bottom: 0.125rem;
+
+    border-bottom: 1px solid;
+    border-color: ${({ theme }) => theme.colors.border.gray100};
+
+    cursor: pointer;
+  }
+`;

--- a/src/pages/waitingCheck/WaitingCheckPage.tsx
+++ b/src/pages/waitingCheck/WaitingCheckPage.tsx
@@ -6,9 +6,11 @@ import Separator from "@components/separator/Separator";
 import WaitingCard from "@components/waitingCard/WaitingCard";
 import WaitingDetailCaution from "@pages/waitingDetail/_components/WaitingDetailCaution";
 import WaitingCheckCautionModal from "./_components/WaitingCheckCautionModal";
+// import useWaitingId from "./_hooks/useWaitingId";
 
 const WaitingCheckPage = () => {
   const [isModalOpen, setModalOpen] = useState(false);
+  // const waitingID = useWaitingId();
 
   const handleOpenModal = () => {
     setModalOpen(true);
@@ -24,8 +26,10 @@ const WaitingCheckPage = () => {
         <S.WaitingCheckPageTitle>
           줄서기를 진행하시겠어요?
         </S.WaitingCheckPageTitle>
+        {/* {waitingID ? ( */}
         <WaitingCard
           type="check"
+          // waitingID={waitingID}
           remainingTeams={3}
           boothInfo={{
             peopleCount: 8,
@@ -33,6 +37,9 @@ const WaitingCheckPage = () => {
             location: "멋쟁이 사자처럼",
           }}
         />
+        {/* ) : (
+          ""
+        )} */}
       </S.WaitingDetailPageBoothCardWrapper>
 
       <Separator />

--- a/src/pages/waitingCheck/WaitingCheckPage.tsx
+++ b/src/pages/waitingCheck/WaitingCheckPage.tsx
@@ -1,5 +1,53 @@
+import { useState } from "react";
+import * as S from "./WaitingCheckPage.styled";
+import BottomButton from "@components/bottomButton/BottomButton";
+import Button from "@components/button/Button";
+import Separator from "@components/separator/Separator";
+import WaitingCard from "@components/waitingCard/WaitingCard";
+import WaitingDetailCaution from "@pages/waitingDetail/_components/WaitingDetailCaution";
+import WaitingCheckCautionModal from "./_components/WaitingCheckCautionModal";
+
 const WaitingCheckPage = () => {
-  return <div>최종 웨이팅 확인 페이지</div>;
+  const [isModalOpen, setModalOpen] = useState(false);
+
+  const handleOpenModal = () => {
+    setModalOpen(true);
+  };
+
+  const handleCloseModal = () => {
+    setModalOpen(false);
+  };
+
+  return (
+    <>
+      <S.WaitingDetailPageBoothCardWrapper>
+        <S.WaitingCheckPageTitle>
+          줄서기를 진행하시겠어요?
+        </S.WaitingCheckPageTitle>
+        <WaitingCard
+          type="check"
+          remainingTeams={3}
+          boothInfo={{
+            peopleCount: 8,
+            boothName: "부스 - A",
+            location: "멋쟁이 사자처럼",
+          }}
+        />
+      </S.WaitingDetailPageBoothCardWrapper>
+
+      <Separator />
+
+      <WaitingDetailCaution />
+
+      <BottomButton>
+        <Button scheme="blue" onClick={handleOpenModal}>
+          <span>계속 진행하기</span>
+        </Button>
+      </BottomButton>
+
+      {isModalOpen && <WaitingCheckCautionModal onClose={handleCloseModal} />}
+    </>
+  );
 };
 
 export default WaitingCheckPage;

--- a/src/pages/waitingCheck/_components/WaitingCheckCautionModal.tsx
+++ b/src/pages/waitingCheck/_components/WaitingCheckCautionModal.tsx
@@ -1,0 +1,53 @@
+import InfoBottomButton from "@components/infobottomButton/InfoBottomButton";
+import Button from "@components/button/Button";
+import ButtonLayout from "@components/button/ButtonLayout";
+import { useNavigate } from "react-router-dom";
+import { useState } from "react";
+import * as S from "./WaitingCheckPeople.styled";
+import iconBefore from "/icons/icon_checkBox_before.svg";
+import iconAfter from "/icons/icon_checkBox_after.svg";
+
+interface WaitingCheckModalProps {
+  onClose: () => void;
+}
+
+const WaitingCheckCautionModal = ({ onClose }: WaitingCheckModalProps) => {
+  const navigate = useNavigate();
+  const [checked, setChecked] = useState(false);
+
+  const handleCancel = () => {
+    console.log("취소 버튼 클릭");
+    onClose();
+  };
+
+  const handleConfirm = () => {
+    console.log("확인 버튼 클릭");
+    navigate("/waiting/1");
+  };
+
+  return (
+    <InfoBottomButton
+      informationTitle="유의사항을 꼭 숙지해주세요"
+      informationSub="입장 순서가 되면 입장 확정 알림이 가요.
+    3분 내로 미확정 시 줄 서기가 자동 취소될 수 있어요."
+    >
+      <S.CheckBoxWrapper onClick={() => setChecked(!checked)}>
+        <S.CheckBoxImage
+          src={checked ? iconAfter : iconBefore}
+          alt="체크 박스"
+        />
+        <span>숙지했어요</span>
+      </S.CheckBoxWrapper>
+      <ButtonLayout $col={2}>
+        <Button scheme="grayLight" shape="outline" onClick={handleCancel}>
+          <span>취소하기</span>
+        </Button>
+        <Button scheme="blue" onClick={handleConfirm} disabled={!checked}>
+          <span>대기 줄 서기</span>
+        </Button>
+      </ButtonLayout>
+    </InfoBottomButton>
+  );
+};
+
+export default WaitingCheckCautionModal;

--- a/src/pages/waitingCheck/_components/WaitingCheckModal.tsx
+++ b/src/pages/waitingCheck/_components/WaitingCheckModal.tsx
@@ -1,0 +1,39 @@
+import InfoBottomButton from "@components/infobottomButton/InfoBottomButton";
+import WaitingCheckPeople from "./WaitingCheckPeople";
+import Button from "@components/button/Button";
+import ButtonLayout from "@components/button/ButtonLayout";
+
+interface WaitingCheckModalProps {
+  onClose: () => void;
+}
+
+const WaitingCheckModal = ({ onClose }: WaitingCheckModalProps) => {
+  const handleCancel = () => {
+    console.log("취소 버튼 클릭");
+    onClose();
+  };
+
+  const handleConfirm = () => {
+    console.log("확인 버튼 클릭");
+  };
+
+  return (
+    <InfoBottomButton
+      informationTitle="입장 인원을 선택해주세요"
+      informationSub="다인원의 경우 부스 내부 사정에 따라 
+        대기 순번이 뒤로 밀릴 수 있습니다."
+    >
+      <WaitingCheckPeople />
+      <ButtonLayout $col={2}>
+        <Button scheme="grayLight" shape="outline" onClick={handleCancel}>
+          <span>취소하기</span>
+        </Button>
+        <Button scheme="blue" onClick={handleConfirm}>
+          <span>확인</span>
+        </Button>
+      </ButtonLayout>
+    </InfoBottomButton>
+  );
+};
+
+export default WaitingCheckModal;

--- a/src/pages/waitingCheck/_components/WaitingCheckModal.tsx
+++ b/src/pages/waitingCheck/_components/WaitingCheckModal.tsx
@@ -2,12 +2,15 @@ import InfoBottomButton from "@components/infobottomButton/InfoBottomButton";
 import WaitingCheckPeople from "./WaitingCheckPeople";
 import Button from "@components/button/Button";
 import ButtonLayout from "@components/button/ButtonLayout";
+import { useNavigate } from "react-router-dom";
 
 interface WaitingCheckModalProps {
   onClose: () => void;
 }
 
 const WaitingCheckModal = ({ onClose }: WaitingCheckModalProps) => {
+  const navigate = useNavigate();
+
   const handleCancel = () => {
     console.log("취소 버튼 클릭");
     onClose();
@@ -15,6 +18,7 @@ const WaitingCheckModal = ({ onClose }: WaitingCheckModalProps) => {
 
   const handleConfirm = () => {
     console.log("확인 버튼 클릭");
+    navigate("/check");
   };
 
   return (

--- a/src/pages/waitingCheck/_components/WaitingCheckModal.tsx
+++ b/src/pages/waitingCheck/_components/WaitingCheckModal.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import InfoBottomButton from "@components/infobottomButton/InfoBottomButton";
 import WaitingCheckPeople from "./WaitingCheckPeople";
 import Button from "@components/button/Button";
@@ -8,16 +9,18 @@ interface WaitingCheckModalProps {
   onClose: () => void;
 }
 
-const WaitingCheckModal = ({ onClose }: WaitingCheckModalProps) => {
+// const WaitingCheckModal = ({ onClose }: WaitingCheckModalProps) => {
+const WaitingCheckModal = ({}: WaitingCheckModalProps) => {
   const navigate = useNavigate();
+  const [checkedPeople, setCheckedPeople] = useState<number | null>(1); // 체크된 인원수 상태 관리
 
   const handleCancel = () => {
     console.log("취소 버튼 클릭");
-    onClose();
+    // onClose();
   };
 
   const handleConfirm = () => {
-    console.log("확인 버튼 클릭");
+    console.log("체크된 인원수:", checkedPeople);
     navigate("/check");
   };
 
@@ -27,7 +30,7 @@ const WaitingCheckModal = ({ onClose }: WaitingCheckModalProps) => {
       informationSub="다인원의 경우 부스 내부 사정에 따라 
         대기 순번이 뒤로 밀릴 수 있습니다."
     >
-      <WaitingCheckPeople />
+      <WaitingCheckPeople onCheck={setCheckedPeople} />
       <ButtonLayout $col={2}>
         <Button scheme="grayLight" shape="outline" onClick={handleCancel}>
           <span>취소하기</span>

--- a/src/pages/waitingCheck/_components/WaitingCheckPeople.styled.ts
+++ b/src/pages/waitingCheck/_components/WaitingCheckPeople.styled.ts
@@ -5,14 +5,13 @@ export const WaitingCheckContainer = styled.div`
   overflow-x: auto;
 
   margin-bottom: 1.75rem;
-
-  //스크롤비 안보이도록
+  /* 
   scrollbar-width: none;
   -ms-overflow-style: none;
 
   &::-webkit-scrollbar {
     display: none;
-  }
+  } */
 `;
 
 export const Circle = styled.div<{ $isChecked: boolean }>`

--- a/src/pages/waitingCheck/_components/WaitingCheckPeople.styled.ts
+++ b/src/pages/waitingCheck/_components/WaitingCheckPeople.styled.ts
@@ -1,0 +1,45 @@
+import styled, { css } from "styled-components";
+
+export const WaitingCheckContainer = styled.div`
+  display: flex;
+  overflow-x: auto;
+
+  margin-bottom: 1.75rem;
+
+  //스크롤비 안보이도록
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+`;
+
+export const Circle = styled.div<{ $isChecked: boolean }>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  width: 3.25rem;
+  height: 3.25rem;
+
+  padding: 0.625rem;
+  margin-right: 1rem;
+
+  border-radius: 2.5rem;
+
+  ${({ $isChecked, theme }) => css`
+    border: 1px solid ${theme.colors.scheme.blue.border};
+    background-color: ${$isChecked ? theme.colors.scheme.blue.background : ""};
+    color: ${$isChecked
+      ? theme.colors.scheme.blue.font
+      : theme.colors.font.blue};
+  `}
+
+  cursor: pointer;
+  flex-shrink: 0;
+
+  &:last-child {
+    margin-right: 0;
+  }
+`;

--- a/src/pages/waitingCheck/_components/WaitingCheckPeople.styled.ts
+++ b/src/pages/waitingCheck/_components/WaitingCheckPeople.styled.ts
@@ -43,3 +43,21 @@ export const Circle = styled.div<{ $isChecked: boolean }>`
     margin-right: 0;
   }
 `;
+
+export const CheckBoxWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  margin-bottom: 1.75rem;
+  cursor: pointer;
+
+  span {
+    ${({ theme }) => theme.fonts.h3};
+    color: ${({ theme }) => theme.colors.font.black};
+  }
+`;
+
+export const CheckBoxImage = styled.img`
+  width: 24px;
+  height: 24px;
+  margin-right: 0.5rem;
+`;

--- a/src/pages/waitingCheck/_components/WaitingCheckPeople.tsx
+++ b/src/pages/waitingCheck/_components/WaitingCheckPeople.tsx
@@ -1,11 +1,17 @@
 import { useState } from "react";
 import * as S from "./WaitingCheckPeople.styled";
 
-const WaitingCheckPeople = () => {
+interface WaitingCheckPeopleProps {
+  onCheck: (num: number | null) => void;
+}
+
+const WaitingCheckPeople = ({ onCheck }: WaitingCheckPeopleProps) => {
   const [checkedPeople, setCheckedPeople] = useState<number | null>(1);
 
   const toggleCheck = (num: number) => {
-    setCheckedPeople((prev) => (prev === num ? null : num));
+    const newCheckedPeople = checkedPeople === num ? null : num;
+    setCheckedPeople(newCheckedPeople);
+    onCheck(newCheckedPeople);
   };
 
   return (

--- a/src/pages/waitingCheck/_components/WaitingCheckPeople.tsx
+++ b/src/pages/waitingCheck/_components/WaitingCheckPeople.tsx
@@ -1,0 +1,31 @@
+import { useState } from "react";
+import * as S from "./WaitingCheckPeople.styled";
+
+const WaitingCheckPeople = () => {
+  const [checkedPeople, setCheckedPeople] = useState<number | null>(1);
+
+  const toggleCheck = (num: number) => {
+    setCheckedPeople((prev) => (prev === num ? null : num));
+  };
+
+  return (
+    <S.WaitingCheckContainer>
+      {[...Array(8)].map((_, index) => {
+        const num = index + 1;
+        const isChecked = checkedPeople === num;
+
+        return (
+          <S.Circle
+            key={num}
+            onClick={() => toggleCheck(num)}
+            $isChecked={isChecked}
+          >
+            {num}명
+          </S.Circle>
+        );
+      })}
+    </S.WaitingCheckContainer>
+  );
+};
+
+export default WaitingCheckPeople;

--- a/src/pages/waitingCheck/_hooks/useWaitingId.ts
+++ b/src/pages/waitingCheck/_hooks/useWaitingId.ts
@@ -1,0 +1,9 @@
+import { useParams } from "react-router-dom";
+
+const useWaitingId = () => {
+  const { waitingID } = useParams<{ waitingID: string }>();
+  // console.log("웨이팅아이디", waitingID);
+  return waitingID;
+};
+
+export default useWaitingId;

--- a/src/pages/waitingDetail/_components/WaitingDetailCaution.styled.tsx
+++ b/src/pages/waitingDetail/_components/WaitingDetailCaution.styled.tsx
@@ -5,7 +5,10 @@ export const WaitingDetailCautionWrapper = styled.div`
 `;
 
 export const WaitingDetailCautionTitle = styled.h3`
+  display: flex;
+  flex-direction: column;
   width: 100%;
+  gap: 0.5rem;
 
   padding: 0rem 0.25rem 0.75rem 0.25rem;
   margin-bottom: 1rem;
@@ -14,6 +17,17 @@ export const WaitingDetailCautionTitle = styled.h3`
   border-color: ${({ theme }) => theme.colors.border.gray075};
 
   ${({ theme }) => theme.fonts.h3};
+`;
+
+export const WaitingDetailCautionSubTitle = styled.div`
+  ${({ theme }) => theme.fonts.b3};
+  color: ${({ theme }) => theme.colors.font.gray};
+  word-break: keep-all;
+  white-space: pre-line;
+
+  span {
+    display: block;
+  }
 `;
 
 export const WaitingDetailCautionItemWrapper = styled.div`

--- a/src/pages/waitingDetail/_components/WaitingDetailCaution.tsx
+++ b/src/pages/waitingDetail/_components/WaitingDetailCaution.tsx
@@ -1,5 +1,6 @@
 import * as S from "./WaitingDetailCaution.styled";
 import WaitingDetailCautionItem from "./WaitingDetailCautionItem";
+import { SUBTITLE, TITLE } from "@constants/waitingCaution";
 
 const WaitingDetailCaution = () => {
   const contents = [
@@ -16,13 +17,9 @@ const WaitingDetailCaution = () => {
   return (
     <S.WaitingDetailCautionWrapper>
       <S.WaitingDetailCautionTitle>
-        라인나우 대기 줄서기 유의사항
+        {TITLE}
         <S.WaitingDetailCautionSubTitle>
-          <span>
-            입장 미확정 또는 입장 시간을 준수하지 않으면 대기 줄서기가 자동
-            취소됩니다.
-          </span>{" "}
-          아래 유의사항을 꼭 읽어주세요.
+          {SUBTITLE}
         </S.WaitingDetailCautionSubTitle>
       </S.WaitingDetailCautionTitle>
       <S.WaitingDetailCautionItemContainer>

--- a/src/pages/waitingDetail/_components/WaitingDetailCaution.tsx
+++ b/src/pages/waitingDetail/_components/WaitingDetailCaution.tsx
@@ -4,15 +4,11 @@ import WaitingDetailCautionItem from "./WaitingDetailCautionItem";
 const WaitingDetailCaution = () => {
   const contents = [
     {
-      text: "대기가 1팀이 남은 경우 문자 알림이가요.\n알림 이후, 3분 내로 대기 확정을 해주세요.\n대기가 취소됩니다.",
+      text: "대기 차례가 오면 카카오톡 알림이 발송됩니다.\n3분 이내에 반드시 ‘입장 확정’을 눌러주세요.\n미확정 시에 대기가 자동 취소됩니다.",
       imgSrc: "/images/image_caution.png",
     },
     {
-      text: "대기가 1팀이 남은 경우 문자 알림이가요.\n알림 이후, 3분 내로 대기 확정을 해주세요.\n대기가 취소됩니다.",
-      imgSrc: "/images/image_caution.png",
-    },
-    {
-      text: "대기가 1팀이 남은 경우 문자 알림이가요.\n알림 이후, 3분 내로 대기 확정을 해주세요.\n대기가 취소됩니다.",
+      text: "입장 확정 시 부스 입장 가능 시간이 부여됩니다.\n반드시 10분 이내에 부스로 입장해주세요.\n10분이 지나면 입장이 제한됩니다.",
       imgSrc: "/images/image_caution.png",
     },
   ];
@@ -20,7 +16,14 @@ const WaitingDetailCaution = () => {
   return (
     <S.WaitingDetailCautionWrapper>
       <S.WaitingDetailCautionTitle>
-        라인나우 유의사항
+        라인나우 대기 줄서기 유의사항
+        <S.WaitingDetailCautionSubTitle>
+          <span>
+            입장 미확정 또는 입장 시간을 준수하지 않으면 대기 줄서기가 자동
+            취소됩니다.
+          </span>{" "}
+          아래 유의사항을 꼭 읽어주세요.
+        </S.WaitingDetailCautionSubTitle>
       </S.WaitingDetailCautionTitle>
       <S.WaitingDetailCautionItemContainer>
         {contents.map((content, index) => (

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -23,6 +23,7 @@ i {font-style:normal}
 	overflow: hidden;
 
 	min-height: 100vh;
+
 }
 
 // 폰트설정
@@ -45,6 +46,7 @@ html {
 	@media (max-width: 360px) {
 		font-size:12px;
 	}
+
 }
 
 body {
@@ -54,7 +56,16 @@ body {
 	overflow-x: hidden;
 	background-color: ${({ theme }) => theme.colors.background.white};
 	color: ${({ theme }) => theme.colors.font.black};
+	
+	scrollbar-width: none; 
+	-ms-overflow-style: none;
+
+	::-webkit-scrollbar {
+    display: none;
 }
+}
+
+
 
 `;
 


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
웨이팅 체크 페이지 UI를 구현했습니다. 
인원수 체크 모달, 유의사항 확인 모달 구현했습니다.


## 🚨 참고 사항
해당 페이지를 구현하는 과정에서 Waiting Card를 props로 받도록 수정했습니다. (확인해보니, main 화면과 부스 확인하는 페이지에서 주로 사용하는 것 같아 type을 main과 check로 나눠 놓긴 했습니다..!) 나중에 실제로 api를 받아오는 부분을 생각하면 props로 넘겨주는게 맞다고 생각했는데, 생각보다 코드가 복잡해지는 것 같아 고민이네욥 ... 혹시 좋은 방법이 있으면 알려주세요오


## 📸 스크린샷
|    구현 내용    |   540px   |   390px   |   320px   |
| :-------------: | :----------: | :----------: | :----------: |
| 입장인원선택 | <img src = "https://github.com/user-attachments/assets/f9781152-5a1e-4b67-be6e-50031aeff411" width ="250"> | <img src = "https://github.com/user-attachments/assets/6e71e9c7-1204-4cab-a47c-fdb9c1737695" width ="250"> | <img src = "https://github.com/user-attachments/assets/cc744a7c-d7e8-476e-b386-b5fe0d5aea65" width ="250"> |

|    구현 내용    |   540px   |   390px   |   320px   |
| :-------------: | :----------: | :----------: | :----------: |
| 줄서기 확인 | <img src = "https://github.com/user-attachments/assets/a6bac7c1-b71d-4505-836c-5465514e8789" width ="250"> | <img src = "https://github.com/user-attachments/assets/4c05c568-b437-4972-8183-6187882e3d41" width ="250"> | <img src = "https://github.com/user-attachments/assets/e17afbc1-47f9-4284-9275-3ea8716b9f3a" width ="250"> |

|    구현 내용    |   540px   |   390px   |   320px   |
| :-------------: | :----------: | :----------: | :----------: |
| 유의사항 확인 | <img src = "https://github.com/user-attachments/assets/484471d1-05b7-4421-9b7e-7705b3865d52" width ="250"> | <img src = "https://github.com/user-attachments/assets/6a8abe47-ebb6-4c73-9cc0-81350e08d1fe" width ="250"> | <img src = "https://github.com/user-attachments/assets/d2e6b217-f038-4176-8b20-46044b0cc72c" width ="250"> |

|    구현 내용    |   540px   |   390px   |   320px   |
| :-------------: | :----------: | :----------: | :----------: |
| 유의사항 체크 | <img src = "https://github.com/user-attachments/assets/933e17d2-b84a-4c65-833a-280dafeff229" width ="250"> | <img src = "https://github.com/user-attachments/assets/62544b8e-2fd0-48c7-80c6-c376d555ba68" width ="250"> | <img src = "https://github.com/user-attachments/assets/07cc5035-e786-45a8-ba3e-53387079adda" width ="250"> |



## 🖥️ 주요 코드 설명
<!-- 주요 코드에 대한 설명을 작성해주세요. -->
`InfoBottomButton`
- 해당 컴포넌트가 열리면서 title, subTitle, 안의 주요 내용, 버튼들이 들어있는 BottomButton입니다.
- 해당 컴포넌트가 열리면 뒷 배경이 불투명한 검정색으로 덮이게 됩니다.
- 입장 확인 바텀시트에서 활용 가능할 것이라 생각합니다!

```typescript
import * as S from "./InfoBottomButton.styled";

interface BottomButtonProps {
  informationTitle?: string;
  informationSub?: string;
  children?: React.ReactNode;
}

const InfoBottomButton = ({
  informationTitle,
  informationSub,
  children,
}: BottomButtonProps) => {
  return (
    <S.InfoBottomButtonBackground>
      <S.InfoBottomButtonWrapper>
        <S.InfoBottomButtonInformationWrapper>
          <span className="title">{informationTitle}</span>
          <span className="subtitle">{informationSub}</span>
        </S.InfoBottomButtonInformationWrapper>

        <S.InfoBottomButtonCheck>{children}</S.InfoBottomButtonCheck>
      </S.InfoBottomButtonWrapper>
    </S.InfoBottomButtonBackground>
  );
};

export default InfoBottomButton;

```

이렇게 되어있고,

이런식으로 활용 가능합니다.

```typescript
 <InfoBottomButton
      informationTitle="입장 인원을 선택해주세요"
      informationSub="다인원의 경우 부스 내부 사정에 따라 
        대기 순번이 뒤로 밀릴 수 있습니다."
    >
// 이 부분이 InfoBottomButtonCheck의 children 입니다.
      <WaitingCheckPeople />
      <ButtonLayout $col={2}>
        <Button scheme="grayLight" shape="outline" onClick={handleCancel}>
          <span>취소하기</span>
        </Button>
        <Button scheme="blue" onClick={handleConfirm}>
          <span>확인</span>
        </Button>
      </ButtonLayout>
    </InfoBottomButton>
```

## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [ ] 전체 변경사항이 500줄을 넘지 않는가?
- > 502줄이네요 ... 다음부턴 짧게 ....


## 📟 관련 이슈
- Resolved: #18 
