### PR TITLE
[Feature] #17 - Create Login Bottom Sheet

### DIFF
--- a/src/components/bottomsheet/Bottomsheet.tsx
+++ b/src/components/bottomsheet/Bottomsheet.tsx
@@ -1,13 +1,13 @@
-import { ReactNode } from "react";
+import { ReactNode } from 'react';
 
 // component
 import {
   BottomsheetBackground,
   BottomsheetContainer,
-} from "./Bottomsheet.styled";
+} from './Bottomsheet.styled';
 
 // hook
-import useBottomsheet from "@hooks/useBottomsheet";
+import useBottomsheet from '@hooks/useBottomsheet';
 
 export interface BottomsheetProps {
   isOpen: boolean;
@@ -15,10 +15,16 @@ export interface BottomsheetProps {
 }
 
 const Bottomsheet = () => {
-  const { bottomsheet } = useBottomsheet();
+  const { bottomsheet, closeBottomsheet } = useBottomsheet();
+
+  const handleBackgroundClick = (event: React.MouseEvent) => {
+    if (event.target === event.currentTarget) {
+      closeBottomsheet();
+    }
+  };
 
   return bottomsheet.isOpen ? (
-    <BottomsheetBackground>
+    <BottomsheetBackground onClick={handleBackgroundClick}>
       <BottomsheetContainer>{bottomsheet.children}</BottomsheetContainer>
     </BottomsheetBackground>
   ) : null;

--- a/src/components/login/LoginBottomsheetContent.styled.ts
+++ b/src/components/login/LoginBottomsheetContent.styled.ts
@@ -1,0 +1,45 @@
+import styled from 'styled-components';
+
+export const LoginBottomsheetContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+`;
+
+export const LoginBottomsheetContentTopWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 0rem 0.25rem;
+  gap: 0.75rem;
+`;
+
+export const LoginBottomsheetContentTopTitle = styled.h1`
+  ${({ theme }) => theme.fonts.h1};
+  color: ${({ theme }) => theme.colors.font.black};
+`;
+
+export const LoginBottomsheetContentTopSubTitle = styled.body`
+  ${({ theme }) => theme.fonts.b1}
+  color: ${({ theme }) => theme.colors.font.blackLight};
+`;
+
+export const LoginBottomsheetContentButton = styled.button`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  width: 100%;
+  height: 3.5rem;
+  padding: 0 1.25rem;
+  gap: 0.5rem;
+  border-radius: 0.5rem;
+
+  background-color: #fee500;
+
+  cursor: pointer;
+`;
+
+export const LoginBottomsheetContentButtonText = styled.span`
+  ${({ theme }) => theme.fonts.btn}
+  color: ${({ theme }) => theme.colors.font.black};
+`;

--- a/src/components/login/LoginBottomsheetContent.tsx
+++ b/src/components/login/LoginBottomsheetContent.tsx
@@ -1,0 +1,27 @@
+import { IconButton } from '@components/button/CustomButton';
+import * as S from './LoginBottomsheetContent.styled';
+
+const LoginBottomsheetContent = () => {
+  return (
+    <S.LoginBottomsheetContentWrapper>
+      <S.LoginBottomsheetContentTopWrapper>
+        <S.LoginBottomsheetContentTopTitle>
+          로그인이 필요해요
+        </S.LoginBottomsheetContentTopTitle>
+        <S.LoginBottomsheetContentTopSubTitle>
+          라인나우에 바로 가입하여 대기 줄 서기를 이용하세요 <br /> 카카오톡으로
+          간편하게 가입할 수 있어요
+        </S.LoginBottomsheetContentTopSubTitle>
+      </S.LoginBottomsheetContentTopWrapper>
+
+      <S.LoginBottomsheetContentButton>
+        <IconButton icon="kakao_kakao" iconSize="1.5rem" />
+        <S.LoginBottomsheetContentButtonText>
+          카카오 로그인으로 시작하기
+        </S.LoginBottomsheetContentButtonText>
+      </S.LoginBottomsheetContentButton>
+    </S.LoginBottomsheetContentWrapper>
+  );
+};
+
+export default LoginBottomsheetContent;

--- a/src/pages/setting/SettingPage.tsx
+++ b/src/pages/setting/SettingPage.tsx
@@ -3,6 +3,10 @@ import SettingItem from './_components/settingItem/SettingItem';
 import SettingDeleteID from './_components/deleteID/SettingDeleteID';
 import useModal from '@hooks/useModal';
 
+// 로그인 바텀 시트 테스트
+import useBottomsheet from '@hooks/useBottomsheet';
+import LoginBottomsheetContent from '@components/login/LoginBottomsheetContent';
+
 const SettingPage = () => {
   const { openModal } = useModal();
 
@@ -21,9 +25,16 @@ const SettingPage = () => {
     openModal(logoutModalProps);
   };
 
+  // 로그인 바텀 시트 테스트
+  const { bottomsheet, openBottomsheet, closeBottomsheet } = useBottomsheet();
+
+  const handleOpenBottomSheetButton = () => {
+    openBottomsheet({ children: <LoginBottomsheetContent /> });
+  };
+
   const settingItemProps = [
     { title: '로그아웃', onClick: handleLogoutClick },
-    { title: '언어설정' },
+    { title: '언어설정', onClick: handleOpenBottomSheetButton },
     { title: '이용약관' },
     { title: '1:1 문의' },
     { title: '개발자 정보' },

--- a/src/pages/setting/SettingPage.tsx
+++ b/src/pages/setting/SettingPage.tsx
@@ -26,7 +26,7 @@ const SettingPage = () => {
   };
 
   // 로그인 바텀 시트 테스트
-  const { bottomsheet, openBottomsheet, closeBottomsheet } = useBottomsheet();
+  const { openBottomsheet } = useBottomsheet();
 
   const handleOpenBottomSheetButton = () => {
     openBottomsheet({ children: <LoginBottomsheetContent /> });


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용

- 카카오 로그인 바텀 시트 UI를 구현했습니다.

## 🚨 참고 사항
현재는 테스트를 위해서 설정 페이지에서 언어 설정을 클릭하면 로그인 바텀 시트가 나오도록 했습니다. 
이는 추후에 제거할 예정입니다. 


## 📸 스크린샷
|    구현 내용    |   540px   |   390px   |   320px   |
| :-------------: | :----------: | :----------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/39965c80-bbd1-47f5-a01a-a5039510fd54" width ="250"> | <img src = "https://github.com/user-attachments/assets/c2ff8ce5-81bf-4cf4-99eb-2c426407eec6" width ="250"> | <img src = "https://github.com/user-attachments/assets/0494b71a-0f57-4e16-9ca1-4d3286a91d71" width ="250"> |


## 🖥️ 주요 코드 설명
<!-- 주요 코드에 대한 설명을 작성해주세요. -->
```typescript
  const { bottomsheet, closeBottomsheet } = useBottomsheet();

  const handleBackgroundClick = (event: React.MouseEvent) => {
    if (event.target === event.currentTarget) {
      closeBottomsheet();
    }
  };
```

바텀 시트가 화면에 보여졌을 때, 배경을 클릭하면 바텀 시트가 사라지게 하기 위해서 Bottomsheet 컴포넌트를 수정했습니다. 


## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?


## 📟 관련 이슈
- Resolved: #17
