### PR TITLE
[Feature] #45 - Language Settings - Managing Status with Jotai

### DIFF
--- a/src/atoms/language.ts
+++ b/src/atoms/language.ts
@@ -1,0 +1,3 @@
+import { atom } from 'jotai';
+
+export const languageAtom = atom<string>('ko');

--- a/src/pages/setting/SettingPage.tsx
+++ b/src/pages/setting/SettingPage.tsx
@@ -4,10 +4,13 @@ import SettingDeleteID from './_components/deleteID/SettingDeleteID';
 import useModal from '@hooks/useModal';
 import { postLogout } from '@apis/domains/auth/logout/apis';
 import { useNavigate } from 'react-router-dom';
+import { useAtom } from 'jotai';
+import { languageAtom } from '@atoms/language';
 
 const SettingPage = () => {
   const { openModal, closeModal } = useModal();
   const navigate = useNavigate();
+  const [language, setLanguage] = useAtom(languageAtom);
 
   // 로그아웃 > 모달창 - 로그아웃하기 클릭
   const handleLogout = async () => {
@@ -42,8 +45,15 @@ const SettingPage = () => {
     },
   };
 
+  // 로그아웃 클릭
   const handleLogoutClick = () => {
     openModal(logoutModalProps);
+  };
+
+  // 언어설정 클릭
+  const handleLanguageClick = () => {
+    setLanguage(prevLanguage => (prevLanguage === 'ko' ? 'en' : 'ko'));
+    console.log(language);
   };
 
   // 이용약관 클릭
@@ -69,7 +79,7 @@ const SettingPage = () => {
 
   const settingItemProps = [
     { title: '로그아웃', onClick: handleLogoutClick },
-    { title: '언어설정' },
+    { title: '언어설정', onClick: handleLanguageClick },
     { title: '이용약관', onClick: handleTermsOfServiceClick },
     { title: '1:1 문의', onClick: handleInquiryClick },
     { title: '개발자 정보', onClick: handleDeveloperInfoClick },


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
언어설정에 대해서 Jotai로 상태 관리를 하였습니다. 


## 🚨 참고 사항
기능은 추후에 추가하겠습니다. 


## 🖥️ 주요 코드 설명
```typescript
import { atom } from 'jotai';

export const languageAtom = atom<string>('ko');
```
jotai로 상태 관리하였고, 기본값은 ko (한국어) 입니다. 


## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?


## 📟 관련 이슈
- Resolved: #45
