### PR TITLE
[Fix] #51 - Fix waiting cancel : waitingID props

### DIFF
--- a/src/components/waitingCard/WaitingCard.tsx
+++ b/src/components/waitingCard/WaitingCard.tsx
@@ -9,6 +9,7 @@ import { Waiting } from "@interfaces/waiting";
 import { useWaitingCard } from "./_hooks/useWaitingCard";
 import { useNavigate } from "react-router-dom";
 import useModal from "@hooks/useModal";
+import { postWaitingCancel } from "@apis/domains/waitingCancel/apis";
 
 interface WaitingCardProps {
   waiting: Pick<
@@ -27,7 +28,7 @@ interface WaitingCardProps {
 
 const WaitingCard = ({ waiting, disableClick = false }: WaitingCardProps) => {
   const navigate = useNavigate();
-  const { openModal } = useModal();
+  const { openModal, closeModal } = useModal();
 
   const targetTime = () => {
     switch (waiting.waitingStatus) {
@@ -45,7 +46,21 @@ const WaitingCard = ({ waiting, disableClick = false }: WaitingCardProps) => {
     sub: "대기를 취소하면 현재 줄 서기가 사라져요.\n그래도 취소하실건가요?",
     primaryButton: {
       children: "줄 서기 취소하기",
+      onClick: async () => {
+        if (!waiting.waitingID) {
+          alert("잘못된 대기 번호입니다.");
+          return;
+        }
+
+        closeModal();
+        try {
+          await postWaitingCancel({ waitingID: waiting.waitingID });
+        } catch (error) {
+          alert("대기 취소 중 문제가 발생했습니다. 다시 시도해주세요.");
+        }
+      },
     },
+
     secondButton: {
       children: "이전으로",
     },
@@ -58,7 +73,9 @@ const WaitingCard = ({ waiting, disableClick = false }: WaitingCardProps) => {
 
   const handleWaitingCard = (event: React.MouseEvent<HTMLDivElement>) => {
     if (!disableClick) {
-      navigate(`/waiting/${waiting.waitingID}`);
+      navigate(`/waiting/${waiting.waitingID}`, {
+        state: waiting.waitingID,
+      });
     } else {
       event.stopPropagation();
     }

--- a/src/pages/waitingCheck/_components/WaitingCheckCautionModal.tsx
+++ b/src/pages/waitingCheck/_components/WaitingCheckCautionModal.tsx
@@ -37,7 +37,7 @@ const WaitingCheckCautionModal = ({
         navigate(`/waiting/${response.booth}`, { state: response });
       }
     } catch (error) {
-      console.error("대기 줄 서기 실패:", error);
+      // console.error("대기 줄 서기 실패:", error);
     }
   };
 

--- a/src/pages/waitingDetail/WaitingDetailPage.tsx
+++ b/src/pages/waitingDetail/WaitingDetailPage.tsx
@@ -19,7 +19,6 @@ const WaitingDetailPage = () => {
   const { data: waitingDetail, isLoading } = useGetWaitingDetail(
     waitingID || 0
   );
-  console.log("웨이팅아이디", waitingID);
   const { openModal, closeModal } = useModal();
 
   const waitingCancelModal = {

--- a/src/pages/waitingDetail/WaitingDetailPage.tsx
+++ b/src/pages/waitingDetail/WaitingDetailPage.tsx
@@ -13,14 +13,13 @@ import { postWaitingCancel } from "@apis/domains/waitingCancel/apis";
 const WaitingDetailPage = () => {
   const location = useLocation();
   const navigate = useNavigate();
-  const waitingData = location.state;
-  const waitingID = waitingData ? waitingData.id : null;
+  const waitingID = location.state;
 
   // 대기 상세 정보 가져오기
   const { data: waitingDetail, isLoading } = useGetWaitingDetail(
     waitingID || 0
   );
-
+  console.log("웨이팅아이디", waitingID);
   const { openModal, closeModal } = useModal();
 
   const waitingCancelModal = {


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
my waiting list와 main의 내 대기 보이는 것에서 웨이팅 디테일로 넘어갈 때 waitingID가 넘어가지 않는걸 해결했습니다.
mywaitinglist와 main에서도 대기 취소 api 연결했습니다.


## 🚨 참고 사항
뷰는 똑같아 스크린샷은 제외하겠습니다!


## 🖥️ 주요 코드 설명
<!-- 주요 코드에 대한 설명을 작성해주세요. -->
`WaitingCard.tsx`
- waitingID를 정의해 state로 넘겨주었습니다.
```typescript
const cancelModal = {
    title: "정말 대기를 취소하시겠어요?",
    sub: "대기를 취소하면 현재 줄 서기가 사라져요.\n그래도 취소하실건가요?",
    primaryButton: {
      children: "줄 서기 취소하기",
      onClick: async () => {
        if (!waiting.waitingID) {
          alert("잘못된 대기 번호입니다.");
          return;
        }

        closeModal();
        try {
          await postWaitingCancel({ waitingID: waiting.waitingID });
        } catch (error) {
          alert("대기 취소 중 문제가 발생했습니다. 다시 시도해주세요.");
        }
      },
    },

    secondButton: {
      children: "이전으로",
    },
  };
```


## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?


## 📟 관련 이슈
- Resolved: #51
