### PR TITLE
[Feauture] #59 - Block Back Btn

### DIFF
--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -60,7 +60,6 @@ export const deleteResponse = async (url: string): Promise<EmptyDTO | null> => {
   } catch (error) {
     const axiosError = error as AxiosError;
     console.error("Response error:", axiosError);
-    console.error("Response error:", axiosError);
     return null;
   }
 };
@@ -79,7 +78,6 @@ export const postResponseNoData = async (
   } catch (error) {
     const axiosError = error as AxiosError;
     console.error("Response error:", axiosError);
-    console.error("Response error:", axiosError);
     return null;
   }
 };
@@ -97,7 +95,6 @@ export const postResponse = async <T>(
     });
 
     console.log("서버 응답:", response); // 응답 내용 로그 추가
-    console.log("서버 응답:", response); // 응답 내용 로그 추가
 
     console.log(
       `[POST] ${url}
@@ -110,7 +107,6 @@ export const postResponse = async <T>(
   } catch (error) {
     const axiosError = error as AxiosError;
 
-    console.error("Response error:", axiosError);
     console.error("Response error:", axiosError);
     return null;
   }

--- a/src/components/waitingCard/WaitingCard.tsx
+++ b/src/components/waitingCard/WaitingCard.tsx
@@ -7,7 +7,7 @@ import { Waiting } from "@interfaces/waiting";
 
 // hooks
 import { useWaitingCard } from "./_hooks/useWaitingCard";
-import { useNavigate } from "react-router-dom";
+import { Navigate, useNavigate } from "react-router-dom";
 import useModal from "@hooks/useModal";
 import { postWaitingCancel } from "@apis/domains/waitingCancel/apis";
 
@@ -47,14 +47,14 @@ const WaitingCard = ({ waiting, disableClick = false }: WaitingCardProps) => {
     primaryButton: {
       children: "줄 서기 취소하기",
       onClick: async () => {
-        if (!waiting.waitingID) {
-          alert("잘못된 대기 번호입니다.");
-          return;
-        }
-
         closeModal();
         try {
-          await postWaitingCancel({ waitingID: waiting.waitingID });
+          if (waiting.waitingID !== undefined) {
+            await postWaitingCancel({ waitingID: waiting.waitingID });
+            return <Navigate to="/" replace={true} />;
+          } else {
+            alert("대기 ID를 찾을 수 없습니다.");
+          }
         } catch (error) {
           alert("대기 취소 중 문제가 발생했습니다. 다시 시도해주세요.");
         }

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -29,6 +29,17 @@ const getDelayedResponse = (responseData: any) => {
   };
 };
 
+const postDelayedResponse = (message: string) => {
+  return async () => {
+    await delay(COMMON_DELAY);
+    return HttpResponse.json({
+      status: true,
+      message: message,
+      code: 200,
+    });
+  };
+};
+
 const deleteDelayedResponse = () => {
   return async () => {
     await delay(COMMON_DELAY);
@@ -80,23 +91,10 @@ export const handlers = [
     getDelayedResponse(dummyWaitingDetailResponse)
   ),
 
-  http.post("/api/v1/waitings/:waitingID/cancel", async ({ params }) => {
-    const { waitingID } = params;
-
-    // 토큰 없이 대기 취소 성공 처리
-    return new HttpResponse(
-      JSON.stringify({
-        message: `Waiting with ID ${waitingID} successfully cancelled`,
-        status: "success",
-      }),
-      {
-        status: 200,
-        headers: {
-          "Content-Type": "application/json",
-        },
-      }
-    );
-  }),
+  http.post(
+    "/api/v1/waitings/:waitingID/cancel",
+    postDelayedResponse(`성공적으로 대기가 취소됐습니다.`)
+  ),
 
   http.post(
     "/api/v1/waitings/:boothId/register",

--- a/src/pages/waitingCheck/_components/WaitingCheckCautionModal.tsx
+++ b/src/pages/waitingCheck/_components/WaitingCheckCautionModal.tsx
@@ -34,7 +34,10 @@ const WaitingCheckCautionModal = ({
       });
 
       if (response) {
-        navigate(`/waiting/${response.booth}`, { state: response });
+        navigate(`/waiting/${response.booth}`, {
+          state: response,
+          replace: true,
+        });
       }
     } catch (error) {
       // console.error("대기 줄 서기 실패:", error);

--- a/src/pages/waitingDetail/WaitingDetailPage.tsx
+++ b/src/pages/waitingDetail/WaitingDetailPage.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useGetWaitingDetail } from "@hooks/apis/waitingDetail";
 import * as S from "./WaitingDetailPage.styled";
@@ -30,7 +31,7 @@ const WaitingDetailPage = () => {
         closeModal();
         try {
           await postWaitingCancel({ waitingID });
-          navigate("/");
+          navigate("/", { replace: true });
         } catch (error) {
           alert("대기 취소 중 문제가 발생했습니다. 다시 시도해주세요.");
         }
@@ -44,6 +45,20 @@ const WaitingDetailPage = () => {
   const onWaitingCancelClick = () => {
     openModal(waitingCancelModal);
   };
+
+  //main으로 이동한 후 뒤로가기 막기
+  useEffect(() => {
+    const handlePopState = (event: PopStateEvent) => {
+      event.preventDefault();
+      navigate("/", { replace: true });
+    };
+
+    window.addEventListener("popstate", handlePopState);
+
+    return () => {
+      window.removeEventListener("popstate", handlePopState);
+    };
+  }, [navigate]);
 
   if (isLoading) {
     return <Spinner />;

--- a/src/pages/waitingDetail/WaitingDetailPage.tsx
+++ b/src/pages/waitingDetail/WaitingDetailPage.tsx
@@ -14,7 +14,7 @@ import { postWaitingCancel } from "@apis/domains/waitingCancel/apis";
 const WaitingDetailPage = () => {
   const location = useLocation();
   const navigate = useNavigate();
-  const waitingID = location.state;
+  const waitingID = location.state.id;
 
   // 대기 상세 정보 가져오기
   const { data: waitingDetail, isLoading } = useGetWaitingDetail(


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
줄 서기 취소 후 메인으로 이동. 이동 후 뒤로가기 실행 안되도록,  
대기 건 후 나의 대기 상세페이지에서 뒤로가기 하면 대기 체크 페이지가 아닌 부스 디테일 페이지로 이동하도록 구현했습니다.


## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
뷰는 똑같아 스크린샷 첨부 제외하겠습니다!



## 🖥️ 주요 코드 설명
<!-- 주요 코드에 대한 설명을 작성해주세요. -->
`WaitingCheckCautionModal.tsx`
- 이동 후 `replace: true`로 뒤로가기 버튼 제한했습니다!
```typescript
  const handleConfirm = async () => {
    try {
      const response = await postWaitingRegister({
        boothId,
        party_size: checkedPeople,
      });

      if (response) {
        navigate(`/waiting/${response.booth}`, {
          state: response,
          replace: true,
        });
      }
    } catch (error) {
      // console.error("대기 줄 서기 실패:", error);
    }
  };
```


## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?


## 📟 관련 이슈
- Resolved: #59
