### PR TITLE
[Chore] #65 - Implement booth open logic

### DIFF
--- a/src/apis/domains/booth/_interfaces.ts
+++ b/src/apis/domains/booth/_interfaces.ts
@@ -13,11 +13,12 @@ export interface Booth {
   location?: string;
   images?: Image[];
   menu?: { name: string; price: number }[];
-  open_time?: string;
+  open_time: string;
   close_time?: string;
   waiting_count?: number;
   is_waiting?: boolean;
   waiting_status?: WaitingStatus;
+  is_operated?: "operating" | "not_started" | "finished";
 }
 
 // GetBoothResponse 함수 정의
@@ -39,5 +40,6 @@ export const GetBoothResponse = (response: Booth): Booth => {
     waiting_count: response.waiting_count,
     is_waiting: response.is_waiting,
     waiting_status: response.waiting_status,
+    is_operated: response.is_operated,
   };
 };

--- a/src/components/entrance/Entrance.tsx
+++ b/src/components/entrance/Entrance.tsx
@@ -75,26 +75,6 @@ export const Entrance = ({ boothID, nextPath }: EntranceProps) => {
           scheme="lime"
           disabled={isCountdownOver} // 타이머 종료 시 버튼 비활성화
           onClick={() =>
-            //추후 확인 후 삭제 예정
-            //             openModal({
-            //               title: "다른 대기가 취소돼요",
-            //               sub: "입장을 확정하면 다른 대기는 취소돼요.\n입장을 확정하시겠어요?",
-            //               secondButton: {
-            //                 children: "이전으로",
-            //                 onClick: () => closeModal(),
-            //               },
-            //               primaryButton: {
-            //                 children: "입장 확정하기",
-            //                 scheme: "lime",
-            //                 onClick: () => {
-            //                   closeModal();
-            //                   navigate(
-            //                     `${nextPath.startsWith("/") ? nextPath : `/${nextPath}`}`
-            //                   );
-            //                 },
-            //               },
-            //             })
-
             handleConfirmEntry(
               openModal,
               closeModal,

--- a/src/pages/boothDetail/BoothDetailPage.tsx
+++ b/src/pages/boothDetail/BoothDetailPage.tsx
@@ -54,24 +54,49 @@ const BoothDetailPage = () => {
           <BoothDetailMenu booth={booth} />
 
           <BottomButton
-            informationTitle="전체 줄"
-            informationSub={`${booth.waiting_count}팀`}
+            informationTitle={
+              booth.is_operated === "not_started" ? "부스 운영 시간" : "전체 줄"
+            }
+            informationSub={
+              booth.is_operated === "not_started"
+                ? new Date(booth.open_time).toLocaleTimeString("ko-KR", {
+                    hour: "2-digit",
+                    minute: "2-digit",
+                  })
+                : `${booth.waiting_count}팀`
+            }
           >
             {isLogin ? (
-              booth.is_waiting ? (
-                <Button scheme="lime">
-                  <span>내 앞으로 지금</span>
-                  <span className="blue">{booth.waiting_count}팀</span>
+              // 로그인 한 경우
+              booth.is_operated === "operating" ? (
+                booth.is_waiting ? (
+                  <Button scheme="lime">
+                    <span>내 앞으로 지금</span>
+                    <span className="blue">{booth.waiting_count}팀</span>
+                  </Button>
+                ) : (
+                  <Button onClick={openModal}>
+                    <span>대기 줄 서기</span>
+                  </Button>
+                )
+              ) : booth.is_operated === "not_started" ? (
+                <Button disabled>
+                  <span>부스 운영 전이에요.</span>
                 </Button>
               ) : (
-                <Button onClick={openModal}>
-                  <span>대기 줄 서기</span>
+                <Button disabled>
+                  <span>대기 줄 서기가 마감되었어요</span>
                 </Button>
               )
             ) : (
+              // 로그인 하지 않은 경우
               <Button scheme="lime" onClick={handleLoginButtonClick}>
                 <span>로그인하고 이용하기</span>
               </Button>
+            )}
+
+            {isModalOpen && (
+              <WaitingCheckModal booth={booth} onClose={closeModal} />
             )}
           </BottomButton>
           {isModalOpen && (


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
부스 오픈 로직을 구현했습니다.

## 🚨 참고 사항


## 📸 스크린샷

## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. -->
`HomeView`
- 최대한 분기 처리를 했지만 조금 더럽네요..ㅠㅠ

```typescript
      <BottomButton
            informationTitle={
              booth.is_operated === "not_started" ? "부스 운영 시간" : "전체 줄"
            }
            informationSub={
              booth.is_operated === "not_started"
                ? new Date(booth.open_time).toLocaleTimeString("ko-KR", {
                    hour: "2-digit",
                    minute: "2-digit",
                  })
                : `${booth.waiting_count}팀`
            }
          >
            {isLogin ? (
              // 로그인 한 경우
              booth.is_operated === "operating" ? (
                booth.is_waiting ? (
                  <Button scheme="lime">
                    <span>내 앞으로 지금</span>
                    <span className="blue">{booth.waiting_count}팀</span>
                  </Button>
                ) : (
                  <Button onClick={openModal}>
                    <span>대기 줄 서기</span>
                  </Button>
                )
              ) : booth.is_operated === "not_started" ? (
                <Button disabled>
                  <span>부스 운영 전이에요.</span>
                </Button>
              ) : (
                <Button disabled>
                  <span>대기 줄 서기가 마감되었어요</span>
                </Button>
              )
            ) : (
              // 로그인 하지 않은 경우
              <Button scheme="lime" onClick={handleLoginButtonClick}>
                <span>로그인하고 이용하기</span>
              </Button>
            )}

            {isModalOpen && (
              <WaitingCheckModal booth={booth} onClose={closeModal} />
            )}
     </BottomButton>
```


## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?


## 📟 관련 이슈
- Resolved: #65 