### PR TITLE
[Fix]#94 - Fix error - navigate to main

### DIFF
--- a/src/components/navigation/Navigation.tsx
+++ b/src/components/navigation/Navigation.tsx
@@ -1,10 +1,11 @@
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
 import * as S from "./Navigation.styled";
 import { IconButton } from "@components/button/CustomButton";
 
 const Navigation = () => {
   const location = useLocation();
+  const navigate = useNavigate();
 
   const getNavigationTitle = () => {
     if (location.pathname.startsWith("/waiting/")) {
@@ -26,7 +27,12 @@ const Navigation = () => {
   };
 
   const handleBackButton = () => {
-    window.history.back();
+    // location.key가 없으면 이전 페이지가 없다고 판단하고, 홈으로 이동
+    if (location.key !== "default") {
+      window.history.back();
+    } else {
+      navigate("");
+    }
   };
 
   return (

--- a/src/hooks/apis/waiting.ts
+++ b/src/hooks/apis/waiting.ts
@@ -17,7 +17,7 @@ import {
   RegisterWaitingRequest,
 } from "@apis/domains/waiting/_interfaces";
 
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
 export const useGetWaiting = ({ ...props }: GetWaitingRequest) => {
   return useQuery({
@@ -44,6 +44,9 @@ export const useGetNowWaitings = (isLogin: boolean, query?: string) => {
 export const usePostWaitingCancel = () => {
   const { closeModal } = useModal();
   const { setLoadings } = useIsLoading();
+  const navigate = useNavigate();
+  const location = useLocation();
+
   return useMutation({
     mutationKey: ["waiting_cancel"],
     mutationFn: (waitingID: number) => {
@@ -52,9 +55,14 @@ export const usePostWaitingCancel = () => {
     },
     onSuccess: () => {
       alert("대기가 취소 되었습니다.");
-      history.go(0);
       setLoadings({ isFullLoading: false });
       closeModal();
+
+      if (location.pathname.startsWith("/waiting")) {
+        navigate("/", { replace: true });
+      } else {
+        window.history.go(0);
+      }
     },
     onError: () => {
       alert("대기 취소에 실패했어요.\n잠시 후 다시 시도해주세요.");


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
웨이팅 디테일에서 대기 취소 후 새로고침이 아닌 main으로 이동
history가 없도록 접근해 뒤로가기 버튼 누르면 main으로 이동


## 🖥️ 주요 코드 설명
<!-- 주요 코드에 대한 설명을 작성해주세요. -->
`Navigation`
- location.key가 없으면 이전 페이지가 없다고 판단하고, 홈으로 이동
```typescript
const handleBackButton = () => {
    if (location.key !== "default") {
      window.history.back();
    } else {
      navigate("");
    }
  };
```


## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?


## 📟 관련 이슈
- Resolved: #94
